### PR TITLE
WordPress dashboard plugin/theme installation/updates

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,5 +23,8 @@ Vagrant.configure("2") do |config|
 		# puppet.options = "--verbose --debug"
 	end
 
+	# Ensure that WordPress can install/update plugins, themes and core
+	config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"
+
 	# Success?
 end


### PR DESCRIPTION
Without this change, WordPress isn't able to install plugins/themes via the dashboard, or update plugins/themes/core via the WordPress dashboard.

This is a dirty hack to ensure that WordPress can install/update plugins, themes and core. It does this by making the /vagrant folder world writeable.

Note: for an already provisioned vagrant box, you'll probably have to run `vagrant reload` for these changes to take effect.

Keep up the great work @rmccue!
