### PR TITLE
Add git to our box

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -25,6 +25,10 @@ package { 'php5-xdebug':
 	require => Package['php5-fpm']
 }
 
+package { 'git-core':
+  ensure => installed
+}
+
 class { 'apt':
   update_timeout       => undef
 }
@@ -51,6 +55,7 @@ sennza::wp {'vagrant.local':
 		Package['php5-gd'],
 		Package['php5-imagick'],
 		Package['php5-xdebug'],
+		Package['git-core'],
 		Class['mysql::server'],
 		Class['mysql::php']
 	]


### PR DESCRIPTION
There has been a few times I've wanted to pull some code down from Github onto my vagrant box just to test it out without adding it into my code repo.

I figured that we'll probably use git later down the track to help with automating our deployment anyways so I can't foresee any harm in adding this.
