### PR TITLE
Support non-default WP locations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,8 @@ database:
     name: wordpress
     user: wordpress
     password: vagrantpassword
+
+# WordPress directory
+# (This is usually `wp`, unless you're transplanting Chassis into
+# an existing project)
+wpdir: wp

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -48,6 +48,7 @@ $config = sz_load_config('/vagrant')
 sennza::wp {'vagrant.local':
 	location          => '/vagrant',
 
+	wpdir             => $config[wpdir],
 	hosts             => $config[hosts],
 	database          => $config[database][name],
 	database_user     => $config[database][user],

--- a/puppet/modules/sennza/manifests/network.pp
+++ b/puppet/modules/sennza/manifests/network.pp
@@ -1,5 +1,6 @@
 define sennza::network (
 	$location,
+	$wpdir = 'wp',
 	$hosts = [],
 	$database = 'wordpress',
 	$database_user = 'root',
@@ -28,7 +29,7 @@ define sennza::network (
 		grant    => ['all'],
 	}
 
-	wp::site {"${location}/wp":
+	wp::site {"${location}/${wpdir}":
 		url => "http://${name}/",
 		name => 'Vagrant Site',
 		require => Mysql::Db[$database],

--- a/puppet/modules/sennza/manifests/site.pp
+++ b/puppet/modules/sennza/manifests/site.pp
@@ -1,5 +1,6 @@
 define sennza::site (
 	$location,
+	$wpdir = 'wp',
 	$hosts = [],
 	$database = 'wordpress',
 	$database_user = 'root',
@@ -28,7 +29,7 @@ define sennza::site (
 		grant    => ['all'],
 	}
 
-	wp::site {"${location}/wp":
+	wp::site {"${location}/${wpdir}":
 		url => "http://${name}/",
 		name => 'Vagrant Site',
 		require => Mysql::Db[$database]

--- a/puppet/modules/sennza/manifests/wp.pp
+++ b/puppet/modules/sennza/manifests/wp.pp
@@ -1,5 +1,6 @@
 define sennza::wp (
 	$location,
+	$wpdir = 'wp',
 	$hosts = [],
 	$database = 'wordpress',
 	$database_user = 'root',
@@ -10,6 +11,7 @@ define sennza::wp (
 	if ( $network == true ) {
 		sennza::network { $name:
 			location => $location,
+			wpdir => $wpdir,
 			hosts => $hosts,
 			database => $database,
 			database_user => $database_user,
@@ -20,6 +22,7 @@ define sennza::wp (
 	else {
 		sennza::site { $name:
 			location => $location,
+			wpdir => $wpdir,
 			hosts => $hosts,
 			database => $database,
 			database_user => $database_user,

--- a/puppet/modules/sennza/templates/multisite.nginx.conf.erb
+++ b/puppet/modules/sennza/templates/multisite.nginx.conf.erb
@@ -11,16 +11,16 @@ server {
 	}
 
 	if (!-e $request_filename) {
-		rewrite ^/(wp-.*) /wp/$1 last;
-		rewrite ^/(wp-admin/.*)$ /wp/$1 last;
+		rewrite ^/(wp-.*) /<%= wpdir %>/$1 last;
+		rewrite ^/(wp-admin/.*)$ /<%= wpdir %>/$1 last;
 
-		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) /wp$1 last;
-		rewrite ^/[_0-9a-zA-Z-]+.*(/wp-admin/.*)$ /wp$1 last;
-		rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ /wp$1 last;
+		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) /<%= wpdir %>$1 last;
+		rewrite ^/[_0-9a-zA-Z-]+.*(/wp-admin/.*)$ /<%= wpdir %>$1 last;
+		rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ /<%= wpdir %>$1 last;
 	}
 
 	location ~* ^/(wp-.*|xmlrpc.php) {
-		alias <%= location %>/wp/$1;
+		alias <%= location %>/<%= wpdir %>/$1;
 	}
 
 	location / {


### PR DESCRIPTION
When using Chassis with certain setups (legacy sites, mainly), it can be handy to allow renaming the `wp` directory.
