### PR TITLE
Use correct domain name for WP

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -49,7 +49,7 @@ class {'sennza': }
 $config = sz_load_config('/vagrant')
 $extensions = sz_extensions('/vagrant/extensions')
 
-sennza::wp {'vagrant.local':
+sennza::wp { $config['hosts'][0]:
 	location          => '/vagrant',
 
 	wpdir             => $config[wpdir],


### PR DESCRIPTION
At the moment, looks like the site name is always set to `vagrant.local` regardless of whatever else we set. Annoying.
