### PR TITLE
Set the PATH correctly for php-fpm workers

### DIFF
--- a/puppet/modules/sennza/templates/php-pool.conf.erb
+++ b/puppet/modules/sennza/templates/php-pool.conf.erb
@@ -353,7 +353,7 @@ chdir = /
 ; the current environment.
 ; Default Value: clean env
 ;env[HOSTNAME] = $HOSTNAME
-;env[PATH] = /usr/local/bin:/usr/bin:/bin
+env[PATH] = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/vagrant_ruby/bin
 ;env[TMP] = /tmp
 ;env[TMPDIR] = /tmp
 ;env[TEMP] = /tmp


### PR DESCRIPTION
Turns out the PATH doesn't include `/opt/vagrant_ruby/bin` by default, which means any gems can't be run from PHP. This is a problem for Mailcatcher. :)

@BronsonQuick #reviewmerge
