### PR TITLE
Add plugins constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Before using Chassis, this is how your system should be set up:
      ```bash
      cd myproject
      mkdir content
+     mkdir content/plugins
+     mkdir content/themes
      ```
 
      Alternatively you can use our Chassis Supercharger as a base:

--- a/wp-config.php
+++ b/wp-config.php
@@ -54,6 +54,12 @@ if ( empty( $_SERVER['HTTP_HOST'] ) ) {
 defined('WP_CONTENT_DIR') or define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/content' );
 defined('WP_CONTENT_URL') or define( 'WP_CONTENT_URL', 'http://' . $_SERVER['HTTP_HOST'] . '/content' );
 
+// ========================
+// Custom Plugins Directory
+// ========================
+defined('WP_PLUGIN_DIR') or define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . '/plugins' );
+defined('WP_PLUGIN_URL') or define( 'WP_PLUGIN_URL', 'http://' . $_SERVER['HTTP_HOST'] . '/content/plugins' );
+
 // =======================
 // Use built-in themes too
 // =======================


### PR DESCRIPTION
There was some confusion with the plugins directory in Chassis for @highergroundstudio. See https://github.com/Chassis/Chassis/issues/98

I've updated the README to include the creation of `plugins` and `themes` directories and I've defined both `WP_PLUGIN_DIR` and `WP_PLUGIN_URL`. Can you see any issues with this going forward @rmccue? #ReviewMerge