### PR TITLE
Avoid warnings on new Puppet versions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,12 @@ Vagrant.configure("2") do |config|
 		module_paths.map! { |rel_path| "/vagrant/" + rel_path }
 		puppet.options = "--modulepath " +  module_paths.join( ':' ).inspect
 
+		# Disable Hiera configuration file
+		puppet.options += " --hiera_config /dev/null"
+
+		# Disable Puppet warnings
+		puppet.options += " --disable_warnings=deprecations"
+
 		#puppet.options = puppet.options + " --verbose --debug"
 	end
 


### PR DESCRIPTION
This might break later, but at this point in time, I don't care. Puppet is breaking the entire way we work, so we may need to migrate completely.

Fixes #112.
