### PR TITLE
Remove Puppet imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 .DS_Store
 .idea
 config.local.yaml
+
+# Ignore symlinked Puppet manifests
+/puppet/manifests/*.pp

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -1,6 +1,3 @@
-# Load extensions
-import "/vagrant/extensions/*/chassis.pp"
-
 $config = sz_load_config('/vagrant')
 $extensions = sz_extensions('/vagrant/extensions')
 $php_extensions = [ 'curl', 'gd', 'mysql' ]

--- a/puppet/preprovision.sh
+++ b/puppet/preprovision.sh
@@ -43,3 +43,13 @@ if [[ ! -f /etc/chassis-updated ]]; then
 
 	touch /etc/chassis-updated
 fi
+
+# Don't set the value to "/vagrant/extensions/*/chassis.pp" if there's no
+# extensions (that's a literal asterisk, by the way)
+shopt -s nullglob
+
+# Symlink extension Puppet files into place
+for file in /vagrant/extensions/*/chassis.pp; do
+	extension=$(basename $(dirname $file))
+	ln -f -s "$file" "/vagrant/puppet/manifests/$extension.pp"
+done

--- a/puppet/puppet.conf
+++ b/puppet/puppet.conf
@@ -1,0 +1,8 @@
+[main]
+# Replicate the system-wide configuration
+# (This removes the templatedir configuration to avoid a warning)
+logdir=/var/log/puppet
+vardir=/var/lib/puppet
+ssldir=/var/lib/puppet/ssl
+rundir=/var/run/puppet
+factpath=$vardir/lib/facter


### PR DESCRIPTION
This converts from using Puppet's `import` to using symlinks into the main directory.

Should let us get away with keeping compatibility with existing extension format.

See #114, #109.
