### PR TITLE
When the user provisions, output login detail

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,6 +102,21 @@ Vagrant.configure("2") do |config|
 		#puppet.options = puppet.options + " --verbose --debug"
 	end
 
+	# Help the user out the first time they provision
+	config.vm.provision :shell do |shell|
+		shell.path = "puppet/postprovision.sh"
+		shell.args = [
+			# 0 = hostname
+			CONF['hosts'][0],
+
+			# 1 = username
+			CONF['admin']['user'],
+
+			# 2 = password
+			CONF['admin']['password']
+		]
+	end
+
 	# Ensure that WordPress can install/update plugins, themes and core
 	if vagrant_version >= "1.3.0"
 		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ]

--- a/puppet/postprovision.sh
+++ b/puppet/postprovision.sh
@@ -1,0 +1,11 @@
+if [[ ! -f /etc/chassis-provisioned ]]; then
+	echo "======================================"
+	echo "Your Chassis box has been provisioned!"
+	echo "======================================"
+	echo
+	echo "URL: http://$1/"
+	echo "Username: $2"
+	echo "Password: $3"
+
+	touch /etc/chassis-provisioned
+fi


### PR DESCRIPTION
First provision:
```bash
$ v provision
==> default: Running provisioner: shell...
    default: Running: /var/folders/hw/q27f_v1d1lq0zpcpl73yc96c0000gn/T/vagrant-shell20141217-91962-kvwbwu.sh
==> default: stdin: is not a tty
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: stdin: is not a tty
==> default: Notice: Compiled catalog for vagrant.local in environment development in 3.94 seconds
==> default: Notice: Finished catalog run in 2.40 seconds
==> default: Running provisioner: shell...
    default: Running: /var/folders/hw/q27f_v1d1lq0zpcpl73yc96c0000gn/T/vagrant-shell20141217-91962-cc7f7r.sh
==> default: stdin: is not a tty
==> default: ======================================
==> default: Your Chassis box has been provisioned!
==> default: ======================================
==> default: 
==> default: URL: http://vagrant.local/
==> default: Username: admin
==> default: Password: password
```

Subsequent provisions:
```bash
$ v provision
==> default: Running provisioner: shell...
    default: Running: /var/folders/hw/q27f_v1d1lq0zpcpl73yc96c0000gn/T/vagrant-shell20141217-91991-zuccvj.sh
==> default: stdin: is not a tty
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: stdin: is not a tty
==> default: Notice: Compiled catalog for vagrant.local in environment development in 4.72 seconds
==> default: Notice: Finished catalog run in 2.30 seconds
==> default: Running provisioner: shell...
    default: Running: /var/folders/hw/q27f_v1d1lq0zpcpl73yc96c0000gn/T/vagrant-shell20141217-91991-m7a0il.sh
==> default: stdin: is not a tty
```

Includes default Vagrant colours:
![screenshot 2014-12-17 18 07 50](https://cloud.githubusercontent.com/assets/21655/5468228/afdcb792-8617-11e4-9438-ecac53944f1a.png)
