### PR TITLE
Allow nginx to handle static assets

### DIFF
--- a/puppet/modules/sennza/templates/site.nginx.conf.erb
+++ b/puppet/modules/sennza/templates/site.nginx.conf.erb
@@ -18,4 +18,8 @@ server {
 		fastcgi_read_timeout 900;
 		include /etc/nginx/fastcgi_params;
 	}
+
+	location ~* \.(js|css|png|jpe?g|gif|ico)$ {
+		log_not_found off;
+	}
 }


### PR DESCRIPTION
I had an issue where missing image assets would take a long time to return a 404. Turns out this was due to each request being handed off to fpm-php by nginx.

Allowing nginx to handle static assets made some useful performance gains, but not sure if this will have unintended effects - thoughts @rmccue?