### PR TITLE
Update VM box to trusty64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,7 +66,7 @@ Vagrant.configure("2") do |config|
 	vagrant_version = Vagrant::VERSION.sub(/^v/, '')
 
 	# We <3 Ubuntu LTS
-	config.vm.box = "hashicorp/precise64"
+	config.vm.box = "ubuntu/trusty64"
 
 	# Having access would be nice.
 	if CONF['ip'] == "dhcp"


### PR DESCRIPTION
This update Chassis to use Trusty LTS as a VM box instead of Precise.

hopefully a fix for #130 