### PR TITLE
Map extra directories into the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,8 +120,14 @@ Vagrant.configure("2") do |config|
 	# Ensure that WordPress can install/update plugins, themes and core
 	if vagrant_version >= "1.3.0"
 		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ]
+		CONF["synced_folders"].each do |from, to|
+			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ]
+		end if CONF["synced_folders"]
 	else
 		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"
+		CONF["synced_folders"].each do |from, to|
+			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777"
+		end if CONF["synced_folders"]
 	end
 
 	# Success?

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -205,3 +205,20 @@ instead, such as:
 .. code-block:: yaml
 
    apt_mirror: http://mirror.optus.net/ubuntu/
+
+
+Synced Folders
+--------------
+
+**Key**: ``synced_folders``
+
+You may want to keep your themes and projects along-side Chassis, instead of
+inside it. You'll need to tell Chassis about these external directories, as it
+won't know how to map them. You can tell Chassis to map some external directories
+into the generated VM like so:
+
+.. code-block:: yaml
+
+   synced_folders:
+     a/host/directory: a/vm/directory
+     "this:ones:got:colons": another/vm/directory


### PR DESCRIPTION
I've got a Wordpress theme that I'd like to keep in a repository with
some non-Wordpress stuff. I want to use Chassis during development, but
I don't want to muck about with Chassis in my repository as well. I can
symlink `Chassis/content` or bits inside it all day long, but the VM
that Chassis creates has no idea what is on the other end of that
symlink.

So, I've added a tiny bit to the Vagrantfile that searches through the
coalesced config for an entry named `synced_folders`. It'll go through
the entire list, mapping the key (on the host filesystem) to the value
(on the virtual filesystem).

Am I insane? I feel like not, but you know, let me know. Should this be an extension? If so, how do you suggest I build it?