### PR TITLE
Avoid referring directly to the latest WordPress version number

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -60,8 +60,8 @@ we also allow swapping this out completely for users who want the flexibility.
 Our built-in version follows the pattern laid out by `WordPress Skeleton`_,
 however you can change this easily if you want.
 
-For example, to swap out the current version (4.0.1) for the latest development
-version:
+For example, to swap out the `current version of WordPress`_ for the latest
+development version:
 
 1. Clone ``https://github.com/WordPress/WordPress.git`` to ``wp-trunk/``
 2. Add ``wpdir: wp-trunk`` to your ``config.local.yaml``
@@ -71,6 +71,7 @@ We want to make this as flexible as possible, without forcing you to run through
 any of these steps if you don't need to.
 
 .. _WordPress Skeleton: https://github.com/markjaquith/WordPress-Skeleton
+.. _current version of WordPress: https://wordpress.org/download/
 
 
 Multisite

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -111,7 +111,7 @@ What's in the box?
 
 By default we want to keep Chassis lean, below is a list of what we include:
 
-* `WordPress`_ (version 4.0.1)
+* `WordPress`_ (latest stable version)
 * `PHP`_ (version 5.4) (includes the `cURL <cURL extension_>`_ and `GD`_ extensions)
 * `nginx`_
 * `MySQL`_
@@ -124,7 +124,7 @@ Note that some tools like phpMyAdmin and Memcache are available instead as
 :doc:`extensions </extend>`, which are installed separately to keep
 Chassis fast.
 
-.. _WordPress: http://wordpress.org/
+.. _WordPress: https://wordpress.org/
 .. _PHP: http://www.php.net/
 .. _cURL extension: http://www.php.net/manual/en/book.curl.php
 .. _GD: http://www.php.net/manual/en/book.image.php


### PR DESCRIPTION
This way it doesn't go stale.