### PR TITLE
Add line to include extra nginx directives into site specific conf file

### DIFF
--- a/puppet/modules/sennza/templates/site.nginx.conf.erb
+++ b/puppet/modules/sennza/templates/site.nginx.conf.erb
@@ -4,6 +4,8 @@ server {
 	root <%= @location %>;
 	client_max_body_size 50M;
 
+	include /etc/nginx/sites-available/<%= @fqdn %>.d/*;
+
 	location / {
 		index index.php index.html index.htm;
 		try_files $uri $uri/ /index.php$is_args$args;


### PR DESCRIPTION
Connected to #20

Why include from within sites-available?

* if the files are in sites-enabled/server.d/*, then the general nginx conf will try to include server.d as well, and will fail, as it's a directory
* since the extra files are fragments of nginx directives, including them on sites-enabled/ will break nginx (missing curly braces, etc)
* extra files could be therefore anywhere, and sites-available is as good as any as long as directories there aren't symlinked to sites-enabled