### PR TITLE
Add ssh forwarding by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,10 +67,10 @@ Vagrant.configure("2") do |config|
 
 	# We <3 Ubuntu LTS
 	config.vm.box = "hashicorp/precise64"
-	
+
 	# Enable SSH forwarding
 	config.ssh.forward_agent = true
-	
+
 	# Having access would be nice.
 	if CONF['ip'] == "dhcp"
 		config.vm.network :private_network, type: "dhcp"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,10 @@ Vagrant.configure("2") do |config|
 
 	# We <3 Ubuntu LTS
 	config.vm.box = "hashicorp/precise64"
-
+	
+	# Enable SSH forwarding
+	config.ssh.forward_agent = true
+	
 	# Having access would be nice.
 	if CONF['ip'] == "dhcp"
 		config.vm.network :private_network, type: "dhcp"


### PR DESCRIPTION
Just a simple little thing to have that makes deploying potentially far more simple.

There may be a reason for not including this by default but I'm not aware of it.