### PR TITLE
Change default PHP version to 5.6

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,4 +72,4 @@ paths:
 
 # PHP version
 # Values: 5.3, 5.4, 5.5, 5.6 (or e.g. 5.3.3)
-php: 5.4
+php: 5.6

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -35,7 +35,7 @@ PHP Version
 
 **Key**: ``php``
 
-PHP 5.4 is included with Chassis by default, plus we register the additional
+PHP 5.6 is included with Chassis by default, plus we register the additional
 repositories for the other versions. We don't download them all automatically,
 to avoid extra download times, but switching is still pretty fast as we
 pre-register the APT repositories.
@@ -48,6 +48,9 @@ To switch to 5.3 for example:
 You can use either a two-part version (``5.3``) or a three-part version
 (``5.3.1``) if you want to pick specifc versions. We support any version between
 5.3.0 and 5.6.x.
+
+.. note::
+   There are a few known issues on Windows with PHP 5.4.
 
 
 WordPress Directory

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -112,7 +112,7 @@ What's in the box?
 By default we want to keep Chassis lean, below is a list of what we include:
 
 * `WordPress`_ (latest stable version)
-* `PHP`_ (version 5.4) (includes the `cURL <cURL extension_>`_ and `GD`_ extensions)
+* `PHP`_ (version 5.6) (includes the `cURL <cURL extension_>`_ and `GD`_ extensions)
 * `nginx`_
 * `MySQL`_
 


### PR DESCRIPTION
Fixes #136 and updates the docs with a note about earlier versions of PHP on Windows.