### PR TITLE
HTTPS support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "wp/wp-content/themes/twentysixteen"]
 	path = wp/wp-content/themes/twentysixteen
 	url = https://github.com/WordPress/twentysixteen
+[submodule "puppet/modules/openssl"]
+	path = puppet/modules/openssl
+	url = https://github.com/camptocamp/puppet-openssl

--- a/config.yaml
+++ b/config.yaml
@@ -42,6 +42,10 @@ apt_mirror: Yes
 # Values: Yes, No
 multisite: No
 
+# Should we use HTTPS URLs?
+# Values: Yes, No
+https: No
+
 # Database configuration
 # (When overriding, include all values)
 database:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -115,6 +115,7 @@ By default we want to keep Chassis lean, below is a list of what we include:
 * `PHP`_ (version 5.6) (includes the `cURL <cURL extension_>`_ and `GD`_ extensions)
 * `nginx`_
 * `MySQL`_
+* `OpenSSL`_
 
 Some tools including `Git`_ and `cURL`_ are installed during setup, but you
 shouldn't rely on these being available. Many more are available as default
@@ -132,6 +133,7 @@ Chassis fast.
 .. _MySQL: http://www.mysql.com/
 .. _Git: http://git-scm.com/
 .. _cURL: http://curl.haxx.se/
+.. _OpenSSL: https://openssl.org/
 
 Rather than providing everything under the sun, we provide a set of sensible
 defaults, along with the ability to change this as needed. This helps keep

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -43,6 +43,7 @@ chassis::wp { $config['hosts'][0]:
 	admin_user        => $config[admin][user],
 	admin_email       => $config[admin][email],
 	admin_password    => $config[admin][password],
+	https             => $config[https],
 
 	extensions        => $extensions,
 

--- a/puppet/modules/chassis/manifests/network.pp
+++ b/puppet/modules/chassis/manifests/network.pp
@@ -10,6 +10,7 @@ define chassis::network (
 	$admin_user     = 'admin',
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
+	$https          = false,
 ) {
 	$extra_hosts = join($hosts, ' ')
 	$server_name = rstrip("${name} ${extra_hosts}")
@@ -26,6 +27,12 @@ define chassis::network (
 		notify => Service['nginx']
 	}
 
+	if ( $https == true ) {
+		$url = "https://${name}/"
+	} else {
+		$url = "http://${name}/"
+	}
+
 	mysql::db {$database:
 		user     => $database_user,
 		password => $database_password,
@@ -34,7 +41,7 @@ define chassis::network (
 	}
 
 	wp::site {"${wpdir}":
-		url            => "http://${name}/",
+		url            => $url,
 		name           => 'Vagrant Site',
 		require        => Mysql::Db[$database],
 		network        => true,

--- a/puppet/modules/chassis/manifests/openssl.pp
+++ b/puppet/modules/chassis/manifests/openssl.pp
@@ -1,0 +1,28 @@
+define chassis::openssl (
+) {
+	file { '/vagrant/certs':
+		ensure => 'directory',
+	}
+
+	# include ::openssl
+
+	# class { '::openssl':
+	  # package_ensure         => latest,
+	  # ca_certificates_ensure => latest,
+	# }
+	
+	$commonname = "*.${fqdn}"
+
+	openssl::certificate::x509 { $fqdn:
+	  country      => 'HM',
+	  organization => $fqdn,
+	  commonname   => $commonname,
+	} ->
+	file { "/vagrant/certs/${fqdn}.crt":
+		ensure => 'present',
+		source => "/etc/ssl/certs/${fqdn}.crt",
+		mode => '0644',
+	}
+
+	include ::openssl-nginx
+}

--- a/puppet/modules/chassis/manifests/site.pp
+++ b/puppet/modules/chassis/manifests/site.pp
@@ -41,4 +41,8 @@ define chassis::site (
 		admin_email    => $admin_email,
 		admin_password => $admin_password,
 	}
+
+	chassis::openssl { $name:
+	}
+
 }

--- a/puppet/modules/chassis/manifests/site.pp
+++ b/puppet/modules/chassis/manifests/site.pp
@@ -10,6 +10,7 @@ define chassis::site (
 	$admin_user     = 'admin',
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
+	$https          = false,
 ) {
 	$extra_hosts = join($hosts, ' ')
 	$server_name = rstrip("${name} ${extra_hosts}")
@@ -26,6 +27,12 @@ define chassis::site (
 		notify => Service['nginx']
 	}
 
+	if ( $https == true ) {
+		$url = "https://${name}/"
+	} else {
+		$url = "http://${name}/"
+	}
+
 	mysql::db {$database:
 		user     => $database_user,
 		password => $database_password,
@@ -34,7 +41,7 @@ define chassis::site (
 	}
 
 	wp::site {"${wpdir}":
-		url => "http://${name}/",
+		url => $url,
 		name => 'Vagrant Site',
 		require => Mysql::Db[$database],
 		admin_user     => $admin_user,

--- a/puppet/modules/chassis/manifests/wp.pp
+++ b/puppet/modules/chassis/manifests/wp.pp
@@ -11,6 +11,7 @@ define chassis::wp (
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
 	$network = false,
+	$https = false,
 
 	$extensions = [],
 ) {
@@ -27,6 +28,7 @@ define chassis::wp (
 			admin_user        => $admin_user,
 			admin_email       => $admin_email,
 			admin_password    => $admin_password,
+			https             => $https,
 		}
 	}
 	else {
@@ -42,6 +44,7 @@ define chassis::wp (
 			admin_user        => $admin_user,
 			admin_email       => $admin_email,
 			admin_password    => $admin_password,
+			https             => $https,
 		}
 	}
 

--- a/puppet/modules/openssl-nginx/manifests/init.pp
+++ b/puppet/modules/openssl-nginx/manifests/init.pp
@@ -1,0 +1,12 @@
+class openssl-nginx {
+	file { "/etc/nginx/sites-available/$fqdn.d":
+		ensure => directory,
+		require => Package['nginx']
+	}
+
+	file { "/etc/nginx/sites-available/$fqdn.d/ssl":
+		content => template('openssl-nginx/site.nginx.conf.ssl.erb'),
+		require => File[ "/etc/nginx/sites-available/$fqdn.d" ],
+		notify => Service['nginx'],
+	}
+}

--- a/puppet/modules/openssl-nginx/templates/site.nginx.conf.ssl.erb
+++ b/puppet/modules/openssl-nginx/templates/site.nginx.conf.ssl.erb
@@ -1,0 +1,4 @@
+listen 443 ssl;
+
+ssl_certificate     /etc/ssl/certs/<%= @fqdn %>.crt;
+ssl_certificate_key /etc/ssl/certs/<%= @fqdn %>.key;


### PR DESCRIPTION
This is currently a WIP.

I'm stuck due to the following error which occurs during provisioning, and it's rather short on details (no file or line number):

```
==> default: Error: Could not run: no such file to load -- inifile
```

The OpenSSL module has two references to `inifile`:
1. https://github.com/camptocamp/puppet-openssl/blob/2fdc822663248265ccb6c5bb6a8b498ada67dc49/lib/puppet/provider/x509_cert/openssl.rb#L39
2. https://github.com/camptocamp/puppet-openssl/blob/4add0969ac876a9d3976540cdf77d9838f37d829/spec/unit/puppet/provider/x509_cert/openssl_spec.rb#L1

I'm guessing that one of these is causing a problem but I'm unsure how to go about debugging it.

Any help, suggestions welcome.
