### PR TITLE
Correct wp-cli config location to be in home dir of vagrant user

### DIFF
--- a/puppet/modules/chassis/manifests/wp.pp
+++ b/puppet/modules/chassis/manifests/wp.pp
@@ -59,11 +59,11 @@ define chassis::wp (
 		content => template('chassis/local-config-extensions.php.erb')
 	}
 
-	file { '/vagrant/.wp-cli':
+	file { '/home/vagrant/.wp-cli':
 		ensure => directory
 	}
 
-	file { '/vagrant/.wp-cli/config.yml':
+	file { '/home/vagrant/.wp-cli/config.yml':
 		content => template('chassis/wp-cli.yml.erb')
 	}
 


### PR DESCRIPTION
Resolves #219