### PR TITLE
Updating comments regarding the use of subdomain mutisite

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,7 +38,7 @@ ip: dhcp
 apt_mirror: Yes
 
 # Should we use multisite?
-# (Set to Yes for subdorectories)
+# (Set to Yes for subdirectories)
 # Values: No, Yes, subdomains
 multisite: No
 

--- a/config.yaml
+++ b/config.yaml
@@ -38,8 +38,8 @@ ip: dhcp
 apt_mirror: Yes
 
 # Should we use multisite?
-# (Only subdirectories are supported currently)
-# Values: Yes, No
+# (Set to Yes for subdorectories)
+# Values: No, Yes, subdomains
 multisite: No
 
 # Database configuration


### PR DESCRIPTION
In the docs it specifies that using subdomains for multisite is possible (http://docs.chassis.io/en/latest/config/#multisite), but the comments in config.yaml say it's not supported  yet. I'm going to assume the docs are correct and that the comments just need to be updated