### PR TITLE
Update ppas

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,7 @@ ip: dhcp
 # built-in repositories, or a mirror domain as a string.
 #
 # Values: Yes, No, or any mirror domain name e.g. http://mirror.optus.net/ubuntu/
-apt_mirror: Yes
+apt_mirror: No
 
 # Should we use multisite?
 # (Set to Yes for subdirectories)

--- a/config.yaml
+++ b/config.yaml
@@ -98,5 +98,5 @@ synced_folders:
 #  - git@github.com:Chassis/memcache.git
 
 # PHP version
-# Values: 5.3, 5.4, 5.5, 5.6 (or e.g. 5.3.3)
+# Values: 5.3, 5.4, 5.5, 5.6, 7.0, 7.1 (or e.g. 5.3.3)
 php: 5.6

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -215,12 +215,12 @@ APT Mirror
 
 **Key**: ``apt_mirror``
 
-To speed up package installation, Chassis will tell Ubuntu to use the closest
+To speed up package installation, Chassis can tell Ubuntu to use the closest
 mirror to you, rather than the main mirror (``ubuntu.com``). This typically
 speeds up installation by decreasing latency, however it may cause slowness with
 some slower or badly-behaving mirrors.
 
-You can tell Chassis to avoid doing this by setting ``apt_mirror: No``
+You can tell Chassis to do this by setting ``apt_mirror: Yes``
 
 If you have a specific mirror you'd like to use, you can set this as the value
 instead, such as:

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -5,8 +5,6 @@ $config = sz_load_config()
 $extensions = sz_extensions('/vagrant/extensions')
 $php_extensions = [ 'curl', 'gd', 'mysql' ]
 
-Class['mysql'] -> Package['php5-mysql']
-
 class { 'chassis::php':
 	extensions => $php_extensions,
 	version => $config[php]


### PR DESCRIPTION
The ppa's for php recently changed so this PR updates them accordingly to fix #256.

As a bonus this also fixes #160.

NB: This PR hasn't accounted for version switching after an initial provision as I'll open a new issue for that. Currently with the ppa's we have at the moment Chassis is broken so merging this is more important that version switching after an initial provision.