### PR TITLE
Add .vagrantplugins to empower extensions

### DIFF
--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,13 +1,3 @@
-#puts "loaded"
-
-# class Command < Vagrant.plugin("2", :command)
-# 	def execute
-# 		puts "Hello!"
-# 		0
-# 	end
-# end
-
-require 'json'
 require_relative "puppet/chassis.rb"
 
 module Chassis

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,0 +1,22 @@
+#puts "loaded"
+
+# class Command < Vagrant.plugin("2", :command)
+# 	def execute
+# 		puts "Hello!"
+# 		0
+# 	end
+# end
+
+require 'json'
+require_relative "puppet/chassis.rb"
+
+module Chassis
+	@@dir = File.dirname(__FILE__)
+
+	def self.load_extension_plugins()
+		subplugins = Dir.glob(File.join(@@dir, "extensions", "*", ".vagrantplugins"))
+		subplugins.each {|pluginfile| load pluginfile}
+	end
+end
+
+Chassis.load_extension_plugins()


### PR DESCRIPTION
Since Vagrant 1.7.0, a `.vagrantplugins` file [has been supported](https://github.com/mitchellh/vagrant/issues/3775). This allows Vagrant boxes to specify any arbitrary Ruby code to be loaded; in particular, Vagrant plugins and custom commands.

While we don't have any uses for this ourselves yet, we should allow extensions to define this.

This code finds any `.vagrantplugins` files in extensions, and loads them in from our primary file.