### PR TITLE
Ensure the sites-available/enabled directories exist

### DIFF
--- a/puppet/modules/chassis/manifests/init.pp
+++ b/puppet/modules/chassis/manifests/init.pp
@@ -23,13 +23,13 @@ class chassis {
 		require    => Package['nginx']
 	}
 
+	file {['/etc/nginx', '/etc/nginx/sites-available', '/etc/nginx/sites-enabled']:
+		ensure => directory
+	}
+
 	file {'/etc/nginx/nginx.conf':
 		content => template('chassis/nginx.conf.erb'),
 		require => Package['nginx'],
 		notify => Service['nginx']
-	}
-
-	file {['/etc/nginx/sites-available', '/etc/nginx/sites-enabled']:
-		ensure => directory
 	}
 }

--- a/puppet/modules/chassis/manifests/init.pp
+++ b/puppet/modules/chassis/manifests/init.pp
@@ -28,4 +28,8 @@ class chassis {
 		require => Package['nginx'],
 		notify => Service['nginx']
 	}
+
+	file {['/etc/nginx/sites-available', '/etc/nginx/sites-enabled']:
+		ensure => directory
+	}
 }


### PR DESCRIPTION
I have a theory about #268: nginx is installed after we try and create the config files. This could happen since we don't have (or need) dependencies between nginx and everything else.

To resolve it, I've added an ensure for the directories. On already working installs, this will be a no-op, as the directories already exist. Puppet will create an implicit dependency between the files and the directory, so this should be fine.

One potential problem is that `/etc/nginx` may not exist, and this isn't in recursive mode. To investigate further.