### PR TITLE
 Always install XML and mbstring extensions

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -3,7 +3,7 @@ import "/vagrant/extensions/*/chassis.pp"
 
 $config = sz_load_config()
 $extensions = sz_extensions('/vagrant/extensions')
-$php_extensions = [ 'curl', 'gd', 'mysql' ]
+$php_extensions = [ 'curl', 'gd', 'mysql', 'xml', 'mbstring' ]
 
 class { 'chassis::php':
 	extensions => $php_extensions,

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -133,16 +133,10 @@ class chassis::php (
 			remove_php_fpm { [ "old", "5.5", "5.6", "7.1" ]:
 				notify => Service["${php_package}-fpm"],
 			}
-			package { [ "${php_package}-mbstring" ]:
-				ensure => latest,
-			}
 		}
 		"7.1": {
 			remove_php_fpm { [ "old", "5.5", "5.6", "7.0" ]:
 				notify => Service["${php_package}-fpm"],
-			}
-			package { [ "${php_package}-mbstring" ]:
-				ensure => latest,
 			}
 		}
 		default: {


### PR DESCRIPTION
I ran into issues with `mbstring` functions not being available on PHP7, which were fixed by https://github.com/Chassis/Chassis/issues/275.

However I am still experiencing issues using these functions when NOT using PHP 7.

Additionally, I also need the `xml` extension installed for all PHP versions. I have updated this to remove the mbstring extensions added earlier for PHP 7 only, and added both these for all versions of PHP.