### PR TITLE
Exit with error code if YAML cannot be parsed

### DIFF
--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -28,6 +28,7 @@ module Chassis
 			rescue Psych::SyntaxError => e
 				# Syntax error of some sort, probably
 				puts "ERROR: Could not load config:\n    #{e.message}"
+				exit 1
 			end
 		end
 


### PR DESCRIPTION
If the YAML file can't be parsed, we should display the error and also quit.