### PR TITLE
Include the XML extension by default

### DIFF
--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -56,9 +56,9 @@ class chassis::php (
 
 	# Add mbstring to all versions of php
 	if versioncmp( "${version}", '5.5') < 0 {
-		$packages = [ "${php_package}-fpm", "${php_package}-cli", "${php_package}-common", 'php-mbstring' ]
+		$packages = [ "${php_package}-fpm", "${php_package}-cli", "${php_package}-common", "${php_package}-xml", 'php-mbstring' ]
 	} else {
-		$packages = [ "${php_package}-fpm", "${php_package}-cli", "${php_package}-common", "${php_package}-mbstring" ]
+		$packages = [ "${php_package}-fpm", "${php_package}-cli", "${php_package}-common", "${php_package}-xml", "${php_package}-mbstring" ]
 	}
 	$prefixed_extensions = prefix($extensions, "${php_package}-")
 


### PR DESCRIPTION
Previously: #276, #280.

Turns out this was a regression.