### PR TITLE
Add no_root_squash to synched folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,14 +111,14 @@ Vagrant.configure("2") do |config|
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	if vagrant_version >= "1.3.0"
-		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ]
+		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ], :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ]
+			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ], :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		end if CONF["synced_folders"]
 	else
-		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"
+		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777", :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777"
+			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777", :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		end if CONF["synced_folders"]
 	end
 


### PR DESCRIPTION
@paulgibbs I've just installed VMWare fusion and I could replicate the error you were having in #300 . Could you please pull down this branch and test it and let me know if if fixes your issue? I'm not sure if Vagrant is smart enough to alter the folder permissions on an existing install so this might only work on a fresh up. Cheers!