### PR TITLE
Add back php zip extension for 5.6+

### DIFF
--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -58,7 +58,7 @@ class chassis::php (
 	if versioncmp( "${version}", '5.5') < 0 {
 		$packages = [ "${php_package}-fpm", "${php_package}-cli", "${php_package}-common", "${php_package}-xml", 'php-mbstring' ]
 	} else {
-		$packages = [ "${php_package}-fpm", "${php_package}-cli", "${php_package}-common", "${php_package}-xml", "${php_package}-mbstring" ]
+		$packages = [ "${php_package}-fpm", "${php_package}-cli", "${php_package}-common", "${php_package}-xml", "${php_package}-mbstring", "${php_package}-zip" ]
 	}
 	$prefixed_extensions = prefix($extensions, "${php_package}-")
 


### PR DESCRIPTION
Fixes #303. 5.3 & 5.4 have this installed by default. It was removed in 5.6+.