### PR TITLE
VMware permissions fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,11 @@ Vagrant.configure("2") do |config|
 	]
 	config.vm.provision :shell, :path => "puppet/preprovision.sh", :args => preprovision_args
 
+	# VMWare Fusion has a bug with file permissions so let's work around it.
+	config.vm.provider :vmware_fusion do |v|
+		File.delete( base_path.to_s + "/local-config-extensions.php") if File.exist?( base_path.to_s + "/local-config-extensions.php")
+	end
+
 	# Provision our setup with Puppet
 	config.vm.provision :puppet do |puppet|
 		puppet.manifests_path = "puppet/manifests"
@@ -111,14 +116,14 @@ Vagrant.configure("2") do |config|
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	if vagrant_version >= "1.3.0"
-		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ], :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
+		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ]
 		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ], :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
+			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ]
 		end if CONF["synced_folders"]
 	else
-		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777", :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
+		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"
 		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777", :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
+			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777"
 		end if CONF["synced_folders"]
 	end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,14 +111,14 @@ Vagrant.configure("2") do |config|
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	if vagrant_version >= "1.3.0"
-		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ]
+		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ], :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ]
+			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ], :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		end if CONF["synced_folders"]
 	else
-		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"
+		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777", :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777"
+			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777", :linux__nfs_options => ["no_root_squash"], :map_uid => 0, :map_gid => 0
 		end if CONF["synced_folders"]
 	end
 


### PR DESCRIPTION
Fixes #300.

VMWare has a known issue with file permissions and provisioning. I've tried all the options we can pass into `config.vm.synced_folder` and I also tried fixing this in Puppet as well but it wouldn't work. Other people have "solved" this problem by using this Vagrant plugin: https://github.com/gael-ian/vagrant-bindfs in the spirit of keeping Chassis as lean as possible this is the best fix for this issue.

@paulgibbs Can you please pull this one down and test it for me? I'm pretty damn sure I've nailed this now after 4 hours of trying different things! Let me know how you go and if it's good I'll get Ryan to review it. Thanks!