### PR TITLE
Add `/extensions` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 config.local.yaml
 /.wp-cli
 /wp-cli.local.yml
+/extensions


### PR DESCRIPTION
When adding an extension to Chassis, e.g. [🐟 ](https://github.com/Chassis/Fish) these `/extensions` folders are not ignored, e.g:

```shell
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

    extensions/fish/

nothing added to commit but untracked files present (use "git add" to track)
```