### PR TITLE
Ignore `/phpmyadmin` symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config.local.yaml
 /.wp-cli
 /wp-cli.local.yml
 /extensions
+/phpmyadmin


### PR DESCRIPTION
When the phpMyAdmin extension is loaded a symbolic link is created in the root folder of Chassis:

> `phpmyadmin -> /vagrant/extensions/phpmyadmin/phpmyadmin`

This should be ignored so the root Chassis repo remains _clean_

