### PR TITLE
Include the {fqdn}.d directory in multisite's Nginx config

### DIFF
--- a/puppet/modules/chassis/templates/multisite.nginx.conf.erb
+++ b/puppet/modules/chassis/templates/multisite.nginx.conf.erb
@@ -7,6 +7,8 @@ server {
 	fastcgi_split_path_info ^(.+\.php)(/.+)$;
 	fastcgi_index index.php;
 
+	include /etc/nginx/sites-available/<%= @fqdn %>.d/*;
+
 	# Handle X-Accel-Redirect file serving
 	location ^~ /blogs.dir {
 		internal;


### PR DESCRIPTION
The [OpenSSL module for Chassis](https://github.com/javorszky/chassis-openssl) doesn't work with Multisite enabled. The cause is that the `{fqdn}.d` directory is not included in the Nginx config for multisite [like it is for single sites](https://github.com/Chassis/Chassis/blob/8186f25bce9ff40345c86811c063a575c747e1c8/puppet/modules/chassis/templates/site.nginx.conf.erb#L11), therefore the host name isn't made available on port 443.

Adding this line to the Nginx config for Multisite means the OpenSSL module works as expected.