### PR TITLE
Use correct site URL for multisite

### DIFF
--- a/puppet/modules/chassis/templates/local-config-db.php.erb
+++ b/puppet/modules/chassis/templates/local-config-db.php.erb
@@ -28,4 +28,5 @@ if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
 if ( empty( $_SERVER['HTTP_HOST'] ) ) {
 	$_SERVER['HTTP_HOST'] = '<%= @name %>';
 }
+defined( 'WP_SITEURL' ) or define( 'WP_SITEURL', 'http://<%= @name %>' );
 <% end %>


### PR DESCRIPTION
Currently a multisite install is set up with the wrong `WP_SITEURL` constant. The result is that although you can access the multisite at the root URL eg. `http://vagrant.local` all the generated links have `/wp` appended to them.