### PR TITLE
Highlight database prefix error better

### DIFF
--- a/puppet/preprovision.sh
+++ b/puppet/preprovision.sh
@@ -51,12 +51,12 @@ if [[ ! -z $CHECK_PREFIX ]] && hash mysql 2>/dev/null; then
 	# Check for tables starting with anything that isn't `wp_`
 	HAS_OTHERS=$(HOME=/root/ mysql wordpress -e 'SHOW TABLES' -s | grep -v -e '^wp_')
 	if [[ ! -z $HAS_OTHERS ]]; then
-		echo "Warning: Since 2016-11-25, Chassis requires defining database.prefix in your"
+		echo "ERROR: Since 2016-11-25, Chassis requires defining database.prefix in your"
 		echo "config.yaml. I found other tables in your database:"
 		echo
 		echo "$HAS_OTHERS"
 		echo
-		echo "You should define database.prefix in your config.local.yaml."
+		echo "You MUST define database.prefix in your config.local.yaml."
 		exit 1
 	fi
 fi

--- a/puppet/preprovision.sh
+++ b/puppet/preprovision.sh
@@ -51,12 +51,12 @@ if [[ ! -z $CHECK_PREFIX ]] && hash mysql 2>/dev/null; then
 	# Check for tables starting with anything that isn't `wp_`
 	HAS_OTHERS=$(HOME=/root/ mysql wordpress -e 'SHOW TABLES' -s | grep -v -e '^wp_')
 	if [[ ! -z $HAS_OTHERS ]]; then
-		echo "ERROR: Since 2016-11-25, Chassis requires defining database.prefix in your"
-		echo "config.yaml. I found other tables in your database:"
-		echo " "
-		echo "$HAS_OTHERS" | sed s/^/\\t/
-		echo " "
-		echo "You MUST define database.prefix in your config.local.yaml."
+		>&2 echo "ERROR: Since 2016-11-25, Chassis requires defining database.prefix in your"
+		>&2 echo "config.yaml. I found other tables in your database:"
+		>&2 echo " "
+		>&2 echo "$HAS_OTHERS" | sed s/^/\\t/
+		>&2 echo " "
+		>&2 echo "You MUST define database.prefix in your config.local.yaml."
 		exit 1
 	fi
 fi

--- a/puppet/preprovision.sh
+++ b/puppet/preprovision.sh
@@ -53,9 +53,9 @@ if [[ ! -z $CHECK_PREFIX ]] && hash mysql 2>/dev/null; then
 	if [[ ! -z $HAS_OTHERS ]]; then
 		echo "ERROR: Since 2016-11-25, Chassis requires defining database.prefix in your"
 		echo "config.yaml. I found other tables in your database:"
-		echo
-		echo "$HAS_OTHERS"
-		echo
+		echo " "
+		echo "$HAS_OTHERS" | sed s/^/\\t/
+		echo " "
 		echo "You MUST define database.prefix in your config.local.yaml."
 		exit 1
 	fi


### PR DESCRIPTION
Fixes #331. Changes "Warning" to "ERROR", indicates that it must be changed, and also writes to stderr which makes it display in red instead of green.