### PR TITLE
Skip setting URLs on install

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -86,7 +86,7 @@ if ( file_exists( WP_CONTENT_DIR . '/config.php' ) ) {
 // =====================
 // URL hacks for Vagrant
 // =====================
-if ( WP_LOCAL_DEV && ! defined('WP_SITEURL') ) {
+if ( WP_LOCAL_DEV && ! defined('WP_SITEURL') && ! defined( 'WP_INSTALLING' ) ) {
 	define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/wp');
 
 	if ( ! defined( 'WP_HOME' ) ) {


### PR DESCRIPTION
These are already set by the `--url` parameter to wp-cli, so they aren't required. `SITEURL` only needs to be overridden on single site, when the nginx rule isn't set up for `/wp-*`

Fixes #336.