### PR TITLE
Remove example extension folder

### DIFF
--- a/extensions/example/chassis.pp
+++ b/extensions/example/chassis.pp
@@ -1,1 +1,0 @@
-#An example extension


### PR DESCRIPTION
As we have a ton of fully-built extensions, I don't know if we need to keep the empty sample extension folder around anymore 