### PR TITLE
Clone extensions shallowly

### DIFF
--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -108,7 +108,7 @@ module Chassis
 					folder = @@dir + '/extensions/' + ext.split('/').last.gsub(/.git$/, '')
 
 					if ! File.exist?( folder )
-						system("git clone %s %s --recursive" % [repo, folder] )
+						system("git clone %s %s --recursive --shallow-submodules --depth 1," % [repo, folder] )
 					end
 				end
 			end


### PR DESCRIPTION
Right now, most extensions are pretty small, so doing a full git clone isn't a huge deal, but we might as well just clone them shallowly, as it is a bit faster.
