### PR TITLE
Added nfs to Vagrant config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,9 +111,9 @@ Vagrant.configure("2") do |config|
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	if vagrant_version >= "1.3.0"
-		config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ]
+		config.vm.synced_folder ".", "/vagrant", :nfs => { :mount_options => ["dmode=777","fmode=777"] }
 		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ]
+			config.vm.synced_folder from, to, :nfs => { :mount_options => ["dmode=777","fmode=777"] }
 		end if CONF["synced_folders"]
 	else
 		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"


### PR DESCRIPTION
Added NFS for the performance boost that can be received when running PHPUnit tests from within the machine. Thanks @BronsonQuick for helping me with the fix and the formatting of the option.

Only added it to the `> 1.3.0` config due to possibility of issues on old installs of Windows machines.

Reference: https://www.vagrantup.com/docs/synced-folders/nfs.html