### PR TITLE
Show php all errors in WP_CLI

### DIFF
--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -10,3 +10,8 @@ define( 'AUTOMATIC_UPDATER_DISABLED', true );
 
 // You'll probably want debug logging during development
 define( 'WP_DEBUG_LOG', true );
+
+// Show all php errors for WP_CLI
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	ini_set( 'display_errors', 1 );
+}


### PR DESCRIPTION
When we're running WP CLI commands it's handy to show all php error logs rather then the default which suppresses those errors.