### PR TITLE
Simplify and fix the NFS configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,24 +106,21 @@ Vagrant.configure("2") do |config|
 		]
 	end
 
+	# Set up synced folders.
+	synced_folders = CONF["synced_folders"].clone
+	synced_folders["."] = "/vagrant"
+
 	# Ensure that WordPress can install/update plugins, themes and core
 	mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]
 
-	config.vm.synced_folder ".", "/vagrant", :mount_options => mount_opts, :nfs => CONF['nfs']
-
-	# Automatically use bindfs if we can.
-	if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")
-		config.bindfs.bind_folder "/vagrant", "/vagrant"
-	end
-
-	CONF["synced_folders"].each do |from, to|
+	synced_folders.each do |from, to|
 		config.vm.synced_folder from, to, :mount_options => mount_opts, :nfs => CONF['nfs']
 
 		# Automatically use bindfs if we can.
 		if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")
 			config.bindfs.bind_folder to, to
 		end
-	end if CONF["synced_folders"]
+	end
 
 	# Success?
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,10 @@
 
 # Warn the user if we're on an old version of Vagrant
 if Gem::Version.new(Vagrant::VERSION) < Gem::Version.new("1.5.0")
-	puts "WARNING: Outdated version of Vagrant"
-	puts "   Chassis requires Vagrant 1.5.0+  "
+	puts "ERROR: Outdated version of Vagrant"
+	puts "  Chassis requires Vagrant 1.5.0+ "
 	puts
+	exit 1
 end
 
 # Check that submodules have been loaded
@@ -38,10 +39,6 @@ module_paths.map! do |path|
 end
 
 Vagrant.configure("2") do |config|
-	# Store the current version of Vagrant for use in conditionals when dealing
-	# with possible backward compatible issues.
-	vagrant_version = Vagrant::VERSION.sub(/^v/, '')
-
 	# Set up potential providers.
 	config.vm.provider "virtualbox" do |vb|
 		# Use linked clones to preserve disk space.
@@ -110,30 +107,23 @@ Vagrant.configure("2") do |config|
 	end
 
 	# Ensure that WordPress can install/update plugins, themes and core
-	if vagrant_version >= "1.3.0"
-		mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]
+	mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]
 
-		config.vm.synced_folder ".", "/vagrant", :mount_options => mount_opts, :nfs => CONF['nfs']
+	config.vm.synced_folder ".", "/vagrant", :mount_options => mount_opts, :nfs => CONF['nfs']
+
+	# Automatically use bindfs if we can.
+	if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")
+		config.bindfs.bind_folder "/vagrant", "/vagrant"
+	end
+
+	CONF["synced_folders"].each do |from, to|
+		config.vm.synced_folder from, to, :mount_options => mount_opts, :nfs => CONF['nfs']
 
 		# Automatically use bindfs if we can.
 		if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")
-			config.bindfs.bind_folder "/vagrant", "/vagrant"
+			config.bindfs.bind_folder to, to
 		end
-
-		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :mount_options => mount_opts, :nfs => CONF['nfs']
-
-			# Automatically use bindfs if we can.
-			if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")
-				config.bindfs.bind_folder to, to
-			end
-		end if CONF["synced_folders"]
-	else
-		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"
-		CONF["synced_folders"].each do |from, to|
-			config.vm.synced_folder from, to, :extra => "dmode=777,fmode=777"
-		end if CONF["synced_folders"]
-	end
+	end if CONF["synced_folders"]
 
 	# Success?
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,8 +114,19 @@ Vagrant.configure("2") do |config|
 		mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]
 
 		config.vm.synced_folder ".", "/vagrant", :mount_options => mount_opts, :nfs => CONF['nfs']
+
+		# Automatically use bindfs if we can.
+		if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")
+			config.bindfs.bind_folder "/vagrant", "/vagrant"
+		end
+
 		CONF["synced_folders"].each do |from, to|
 			config.vm.synced_folder from, to, :mount_options => mount_opts, :nfs => CONF['nfs']
+
+			# Automatically use bindfs if we can.
+			if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")
+				config.bindfs.bind_folder to, to
+			end
 		end if CONF["synced_folders"]
 	else
 		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,17 +111,12 @@ Vagrant.configure("2") do |config|
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	if vagrant_version >= "1.3.0"
-		if CONF['nfs'] == true
-			config.vm.synced_folder ".", "/vagrant", :nfs => { :mount_options => ["dmode=777","fmode=777"] }
-			CONF["synced_folders"].each do |from, to|
-				config.vm.synced_folder from, to, :nfs => { :mount_options => ["dmode=777","fmode=777"] }
-			end if CONF["synced_folders"]
-		else
-			config.vm.synced_folder ".", "/vagrant", :mount_options => [ "dmode=777,fmode=777" ]
-			CONF["synced_folders"].each do |from, to|
-				config.vm.synced_folder from, to, :mount_options => [ "dmode=777,fmode=777" ]
-			end if CONF["synced_folders"]
-		end
+		mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]
+
+		config.vm.synced_folder ".", "/vagrant", :mount_options => mount_opts, :nfs => CONF['nfs']
+		CONF["synced_folders"].each do |from, to|
+			config.vm.synced_folder from, to, :mount_options => mount_opts, :nfs => CONF['nfs']
+		end if CONF["synced_folders"]
 	else
 		config.vm.synced_folder ".", "/vagrant", :extra => "dmode=777,fmode=777"
 		CONF["synced_folders"].each do |from, to|

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -251,6 +251,24 @@ into the generated VM like so:
      a/host/directory: a/vm/directory
      "this:ones:got:colons": another/vm/directory
 
+NFS
+~~~
+
+**Key**: ``nfs``
+
+Under the hood, Vagrant uses the default synced folders implementation for your system.
+In certain cases and uses, this might be too slow for everyday usage.
+You can instead use NFS under the hood, which has much better performance, but requires root on your computer.
+
+.. code-block:: yaml
+
+   nfs: true
+
+We highly recommend also installing the `vagrant-bindfs`_ plugin, which ensures that users are correctly mapped into the virtual machine for you.
+If you're experiencing permissions errors, try installing this before anything else.
+
+.. _vagrant-bindfs: https://github.com/gael-ian/vagrant-bindfs
+
 Paths
 -----
 

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -92,6 +92,9 @@ module Chassis
 			end
 		end
 
+		# Cast NFS to bool
+		config["nfs"] = !!config["nfs"]
+
 		return config
 	end
 


### PR DESCRIPTION
PR on #406.

* Fixes the mount options to actually be used.
* Refactors to remove duplication.
* Automatically uses `vagrant-bindfs` per #307 if available.
* Adds documentation for the NFS setting.

Tested on:
* [x] VirtualBox with default
* [x] VirtualBox with default + vagrant-bindfs
* [x] VirtualBox with nfs
* [x] VirtualBox with nfs + vagrant-bindfs
* [ ] VMware with default
* [ ] VMware with default + vagrant-bindfs
* [x] VMware with nfs
* [x] VMware with nfs + vagrant-bindfs

To test: vary `nfs` option in YAML, and try with the bindfs plugin installed (`vagrant plugin install vagrant-bindfs` `vagrant plugin uninstall vagrant-bindfs`).