### PR TITLE
Cast PHP version to string when converting

### DIFF
--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -119,8 +119,9 @@ module Chassis
 			end
 		end
 
-		# Cast NFS to bool
+		# Cast config as needed
 		config["nfs"] = !!config["nfs"]
+		config["php"] = config["php"].to_s
 
 		return config
 	end


### PR DESCRIPTION
The YAML parser will take `7.0` as a float, but `7.0.1` as a string. For consistency, and compatibility with versioncmp(), we need this as a string always.

Fixes #419. Obsoletes #420.