### PR TITLE
Update stdlib and use include apt rather than declare

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -12,7 +12,7 @@ if $loadable_extensions {
 	}
 }
 
-class { 'apt': }
+include apt
 
 class { 'chassis::php':
 	extensions => $php_extensions,


### PR DESCRIPTION
This is to support some more modern modules - I ran into the following issues:

```
Error: Unknown function validate_integer at /vagrant/extensions
```

Updating stdlib to 4.19.0 removed that issue, resolved after 4.15.0 as far as I can tell.

Next issue:

```
Error: Duplicate declaration: Class[Apt] is already declared; ... in ... development.pp
```

Resolved by changing `class { 'apt': }` to `include apt`.

Would be good to test the knock on effect of this on some the more popular extensions first I think, plus maybe some of the other modules could be updated at the same time.