### PR TITLE
Add a default wp-cli config for a vagrant alias

### DIFF
--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,2 @@
+@local:
+  ssh: vagrant:default


### PR DESCRIPTION
This uses the new vagrant scheme in wp-cli to enable a default out-of-the-box alias to call wp-cli commands within vagrant environment without the need to ssh into vagrant first.

Usage would be something like `wp @local user list` or `wp @local shell`.