### PR TITLE
Enable the /myblog/xmlrpc.php route in multisite mode

### DIFF
--- a/puppet/modules/chassis/templates/multisite.nginx.conf.erb
+++ b/puppet/modules/chassis/templates/multisite.nginx.conf.erb
@@ -25,6 +25,7 @@ server {
 		# rewrite ^/(wp-admin/.*)$ <%= @wpdir %>/$1 last;
 
 		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
+		rewrite ^/[_0-9a-zA-Z-]+(/xmlrpc.php) $1 last;
 		rewrite ^/[_0-9a-zA-Z-]+.*(/wp-admin/.*)$ $1 last;
 		# rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ <%= @wpdir %>$1 last;
 	}


### PR DESCRIPTION
If I create a multisite box in Chassis (`multisite: Yes`), create a secondary site (`example.com/myblog`) and connect it with Jetpack, then WordPress.com servers will start issuing POST requests to `/myblog/xmlrpc.php`. This route doesn't work in Chassis, however -- it returns a 404.

This patch fixes that by adding a rewrite rule to the nginx config.