### PR TITLE
Add notice that `paths.wp` be used instead of `wpdir`

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -67,6 +67,8 @@ You can use either a two-part version (``5.3``) or a three-part version
 WordPress Directory
 -------------------
 
+**Note**: Deprecated; use ``paths.wp`` instead.
+
 **Key**: ``wpdir``
 
 Chassis also includes the latest-released version of WordPress by default, but


### PR DESCRIPTION
This is a half-measure, but if it saves somebody some time before the `wpdir` and `paths` sections can be more thoroughly integrated, it may be worthwhile!