### PR TITLE
Multisite subsite hosts

### DIFF
--- a/puppet/modules/chassis/files/chassis-hosts.service
+++ b/puppet/modules/chassis/files/chassis-hosts.service
@@ -4,5 +4,6 @@ Description=Chassis subdomain hosts updater
 [Service]
 TimeoutStartSec=0
 TimeoutStopSec=600
-Restart=always
+Restart=on-failure
+RestartSec=30s
 ExecStart=/usr/bin/python /vagrant/puppet/chassis-hosts.py

--- a/puppet/modules/chassis/files/chassis-hosts.service
+++ b/puppet/modules/chassis/files/chassis-hosts.service
@@ -7,3 +7,6 @@ TimeoutStopSec=600
 Restart=on-failure
 RestartSec=30s
 ExecStart=/usr/bin/python /vagrant/puppet/chassis-hosts.py
+
+[Install]
+WantedBy=multi-user.target

--- a/puppet/modules/chassis/files/chassis-hosts.service
+++ b/puppet/modules/chassis/files/chassis-hosts.service
@@ -6,6 +6,7 @@ TimeoutStartSec=0
 TimeoutStopSec=600
 Restart=on-failure
 RestartSec=30s
+StartLimitBurst=5
 ExecStart=/usr/bin/python /vagrant/puppet/chassis-hosts.py
 
 [Install]

--- a/puppet/modules/chassis/manifests/hosts.pp
+++ b/puppet/modules/chassis/manifests/hosts.pp
@@ -31,7 +31,7 @@ class chassis::hosts(
 
 		file { '/etc/chassis-hosts/conf.d/subdomains':
 			ensure => file,
-			owner  => 'www-data',
+			mode   => '0777',
 		}
 
 		file { '/vagrant/local-config-hosts.php':

--- a/puppet/modules/chassis/manifests/hosts.pp
+++ b/puppet/modules/chassis/manifests/hosts.pp
@@ -41,6 +41,7 @@ class chassis::hosts(
 
 		service { 'chassis-hosts':
 			ensure  => running,
+			enable  => true,
 			require => [
 				Package[ 'avahi-daemon' ],
 				Package[ 'python-avahi' ],


### PR DESCRIPTION
This fixes #510.

We had the `/etc/chassis-hosts/conf.d/subdomains` set to the www-data user which meant that we could add sites through the admin but if we added a site in wp-cli it would run as the vagrant user and not be able to write it. To solve this we can just make the file world writeable as it's only for local development.

I also noticed that our `chassis-hosts` service wasn't starting on a `vagrant up` so I fixed that as well.