### PR TITLE
Escape the directory name

### DIFF
--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -160,6 +160,6 @@ module Chassis
 
 		folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/.git$/, '').downcase
 
-		system("git clone %s %s --recursive" % [repo, folder] ) unless File.exist?( folder )
+		system("git clone %s %s --recursive" % [repo, Shellwords.escape(folder)] ) unless File.exist?( folder )
 	end
 end


### PR DESCRIPTION
Fixes #542.

@rmccue I haven't got an example of a parent directory with a space in the name so if you do could you please test this works as expected?

I've tested it on a vanilla install with one extension and it worked as expected. Thanks!