### PR TITLE
Do not install plugins or themes until WordPress is available.

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -55,14 +55,20 @@ chassis::wp { $config['hosts'][0]:
 	admin_user        => $config[admin][user],
 	admin_email       => $config[admin][email],
 	admin_password    => $config[admin][password],
-	plugins           => $config[plugins],
-	themes            => $config[themes],
 
 	extensions        => $extensions,
 
-	require  => [
+	require => [
 		Class['chassis::php'],
 		Package['git-core'],
 		Class['mysql::server'],
 	]
+}
+
+# Tasks wp::plugin and wp::theme run onlyif "/usr/bin/wp core is-installed":
+# sequence chassis::content after chassis::wp.
+-> chassis::content { $config['hosts'][0]:
+	location => $config[mapped_paths][base],
+	plugins  => $config[plugins],
+	themes   => $config[themes],
 }

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -65,10 +65,11 @@ chassis::wp { $config['hosts'][0]:
 	]
 }
 
-# Tasks wp::plugin and wp::theme run onlyif "/usr/bin/wp core is-installed":
-# sequence chassis::content after chassis::wp.
--> chassis::content { $config['hosts'][0]:
+chassis::content { $config['hosts'][0]:
 	location => $config[mapped_paths][base],
 	plugins  => $config[plugins],
 	themes   => $config[themes],
+
+	# These tasks will not run unless WP is installed.
+	require  => Chassis::Wp[ $config['hosts'][0] ],
 }

--- a/puppet/modules/chassis/manifests/content.pp
+++ b/puppet/modules/chassis/manifests/content.pp
@@ -1,0 +1,16 @@
+# Install our WordPress site and add our configuration.
+define chassis::content (
+	$location,
+	$plugins = [],
+	$themes = [],
+) {
+  wp::plugin { $plugins:
+    ensure   => 'enabled',
+    location => $location,
+  }
+
+  wp::theme { $themes:
+    ensure   => 'enabled',
+    location => $location,
+  }
+}

--- a/puppet/modules/chassis/manifests/content.pp
+++ b/puppet/modules/chassis/manifests/content.pp
@@ -1,4 +1,4 @@
-# Install our WordPress site and add our configuration.
+# Install WordPress themes and plugins.
 define chassis::content (
 	$location,
 	$plugins = [],

--- a/puppet/modules/chassis/manifests/content.pp
+++ b/puppet/modules/chassis/manifests/content.pp
@@ -4,13 +4,13 @@ define chassis::content (
 	$plugins = [],
 	$themes = [],
 ) {
-  wp::plugin { $plugins:
-    ensure   => 'enabled',
-    location => $location,
-  }
+	wp::plugin { $plugins:
+		ensure   => 'enabled',
+		location => $location,
+	}
 
-  wp::theme { $themes:
-    ensure   => 'enabled',
-    location => $location,
-  }
+	wp::theme { $themes:
+		ensure   => 'enabled',
+		location => $location,
+	}
 }

--- a/puppet/modules/chassis/manifests/wp.pp
+++ b/puppet/modules/chassis/manifests/wp.pp
@@ -13,8 +13,6 @@ define chassis::wp (
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
 	$network = false,
-	$plugins = [],
-	$themes = [],
 
 	$extensions = [],
 ) {
@@ -70,15 +68,5 @@ define chassis::wp (
 
 	file { '/home/vagrant/.wp-cli/config.yml':
 		content => template('chassis/wp-cli.yml.erb')
-	}
-
-	wp::plugin { $plugins:
-		ensure   => 'enabled',
-		location => $location,
-	}
-
-	wp::theme { $themes:
-		ensure   => 'enabled',
-		location => $location,
 	}
 }


### PR DESCRIPTION
`wp::plugin` & `wp::theme` run `onlyif  => "/usr/bin/wp core is-installed"`, so because the `chassis::wp` def doesn't do any explicit task sequencing these tasks run before `chassis::site` & silently fail on `vagrant up`. Plugins & Themes will only be installed on subsequent provisions.

To fulfill the expectation that the state described in your yaml config describes the state the box will be on after the initial provision, this PR breaks the `wp::plugin` and `wp::theme` calls into a separate dev which gets explicitly sequenced after `chassis::wp`. This ensures that the WordPress environment is available when we attempt installation, allowing plugins and themes to be pulled down in the initial `vagrant up`.

Fixes #549