### PR TITLE
Remove the stale submodule reference to twentysixteen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "puppet/modules/apt"]
 	path = puppet/modules/apt
 	url = https://github.com/puppetlabs/puppetlabs-apt.git
-[submodule "wp/wp-content/themes/twentysixteen"]
-	path = wp/wp-content/themes/twentysixteen
-	url = https://github.com/WordPress/twentysixteen
 [submodule "puppet/modules/wp"]
 	path = puppet/modules/wp
 	url = https://github.com/Chassis/puppet-wp.git


### PR DESCRIPTION
This should fix #540 properly. The "Read the docs" team have disabled submodule cloning with a flag so at the moment our docs are building again. https://github.com/rtfd/readthedocs.org/issues/4371#issuecomment-405273247