### PR TITLE
Add support for PHP extensions and ini overrides

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -63,6 +63,29 @@ You can use either a two-part version (``5.3``) or a three-part version
 .. note::
    There are a few known issues on Windows with PHP 5.4.
 
+PHP Configuration
+-----------------
+
+**Key**: ``php_config``
+
+While Chassis provisions PHP with the necessary packages and standard configuration
+needed to run WordPress these might not always match the set up you have in
+production, or you may want to modify certain configuration settings to test against.
+
+To add extra extensions such as `intl` or override the default `php.ini`
+settings add a section to your config file like so::
+
+   php_config:
+      extensions:
+         - intl
+         - pdo
+         - imagick
+      ini:
+         memory_limit: 256M
+         post_max_size: 10M
+
+.. note::
+   Available extensions may depend on the version of PHP configured.
 
 WordPress Directory
 -------------------

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -17,6 +17,7 @@ include apt
 class { 'chassis::php':
 	extensions => $php_extensions,
 	version => $config[php],
+	config => $config[php_config],
 	require => [
 		Class['apt'],
 	],

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -2,6 +2,7 @@
 class chassis::php (
 	$extensions = [],
 	$version = '5.6',
+	$config = {},
 ) {
 	# Ensure add-apt-repository is actually available.
 	if !defined(Package[$::apt::ppa_package]) {
@@ -13,6 +14,13 @@ class chassis::php (
 	apt::ppa { 'ppa:ondrej/php':
 		require => [ Package[ $::apt::ppa_package ] ],
 	}
+
+	$defaults = {
+		ini => {},
+		extensions => [],
+	}
+
+	$options = deep_merge($defaults, $config)
 
 	if $version =~ /^(\d+)\.(\d+)$/ {
 		$package_version = "${version}.*"
@@ -78,7 +86,9 @@ class chassis::php (
 			"${php_package}-zip"
 		]
 	}
-	$prefixed_extensions = prefix($extensions, "${php_package}-")
+
+	$all_extensions = union($extensions, $options[extensions])
+	$prefixed_extensions = prefix($all_extensions, "${php_package}-")
 
 	# Hold the packages at the necessary version
 	apt::pin { $packages:

--- a/puppet/modules/chassis/templates/php.ini.erb
+++ b/puppet/modules/chassis/templates/php.ini.erb
@@ -1822,3 +1822,8 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+
+; Custom Chassis config overrides
+<% @options["ini"].each do |key,value| %>
+<%= key %>=<%= value %>
+<% end %>


### PR DESCRIPTION
Allows setting PHP extensions and overrides using the following syntax:

```
php_config:
  ini:
    memory_limit: 256M
  extensions:
    - intl
```

Fixes #551 