### PR TITLE
Remove the default case as we don't need it anymore

### DIFF
--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -118,6 +118,8 @@ class chassis::php (
 				notify => Service["${php_package}-fpm"],
 			}
 		}
+		default:
+		}
 	}
 
 	# Install the extensions we need

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -118,11 +118,6 @@ class chassis::php (
 				notify => Service["${php_package}-fpm"],
 			}
 		}
-		default: {
-			remove_php_fpm { [ '5.6', '7.1', '7.2' ]:
-				notify => Service["${php_package}-fpm"],
-			}
-		}
 	}
 
 	# Install the extensions we need


### PR DESCRIPTION
Fixes #555.

I've tested this on 5.6, 7.0, 7.1 and 7.2.