### PR TITLE
Add the ${name}.d directory when provisioning a network as well

### DIFF
--- a/puppet/modules/chassis/manifests/network.pp
+++ b/puppet/modules/chassis/manifests/network.pp
@@ -27,6 +27,12 @@ define chassis::network (
 		content => template('chassis/multisite.nginx.conf.erb'),
 		notify  => Service['nginx']
 	}
+	if ( ! defined( File["/etc/nginx/sites-available/${name}.d"] ) ) {
+		file { "/etc/nginx/sites-available/${name}.d":
+			ensure  => directory,
+			require => Package['nginx']
+		}
+	}
 	file { "/etc/nginx/sites-enabled/${name}":
 		ensure => link,
 		target => "/etc/nginx/sites-available/${name}",


### PR DESCRIPTION
This was added to `site.pp` but not `network.pp`.