### PR TITLE
Make the WordPress site title configurable through yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,11 @@
 hosts:
     - vagrant.local
 
+# Site Configuration
+# (When overriding, include all values)
+site:
+    name: Chassis Site
+
 # IP address to use on the private network
 #
 # DHCP is used by default to assign IP addresses dynamically, override only if

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -343,6 +343,18 @@ To find the slug just copy and paste the plugins slug from your browsers. For ex
 
 .. _extension-format-ref:
 
+Site Title
+----------
+
+**Key**: ``site``
+
+You can customize the title Chassis uses when installing your local WordPress site.
+
+.. code-block:: yaml
+
+   site:
+      name: My Local WordPress Site
+
 Extensions
 ----------
 

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -55,6 +55,7 @@ chassis::wp { $config['hosts'][0]:
 	admin_user        => $config[admin][user],
 	admin_email       => $config[admin][email],
 	admin_password    => $config[admin][password],
+	sitename          => $config[site][name],
 
 	extensions        => $extensions,
 

--- a/puppet/modules/chassis/manifests/site.pp
+++ b/puppet/modules/chassis/manifests/site.pp
@@ -11,6 +11,7 @@ define chassis::site (
 	$admin_user     = 'admin',
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
+	$sitename       = 'Chassis Site',
 ) {
 	$extra_hosts = join($hosts, ' ')
 	$server_name = rstrip("${name} ${extra_hosts}")
@@ -42,7 +43,7 @@ define chassis::site (
 
 	wp::site { $wpdir:
 		url            => "http://${name}/",
-		name           => 'Vagrant Site',
+		sitename       => $sitename,
 		require        => Mysql::Db[$database],
 		admin_user     => $admin_user,
 		admin_email    => $admin_email,

--- a/puppet/modules/chassis/manifests/wp.pp
+++ b/puppet/modules/chassis/manifests/wp.pp
@@ -12,6 +12,7 @@ define chassis::wp (
 	$admin_user     = 'admin',
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
+	$sitename       = 'Chassis Site',
 	$network = false,
 
 	$extensions = [],
@@ -46,6 +47,7 @@ define chassis::wp (
 			admin_user        => $admin_user,
 			admin_email       => $admin_email,
 			admin_password    => $admin_password,
+			sitename          => $sitename,
 		}
 	}
 


### PR DESCRIPTION
While working on client projects it can be a nice touch to ensure a new VM has the appropriate site title. There was a line of code in chassis which seemed to try to set the installed name to 'Vagrant Site,' but it was using the wrong wp::site parameter and it did not allow the value to be configured. This patch adds a new `site` key to the YAML file, permitting users to specity a `name` value to use as the site title for their new VM.