### PR TITLE
Add global extensions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,10 +33,7 @@ module_paths = [ base_path.to_s + "/puppet/modules" ]
 module_paths.concat Dir.glob( base_path.to_s + "/extensions/*/modules" )
 
 # Convert to relative from Vagrantfile
-module_paths.map! do |path|
-	pathname = Pathname.new(path)
-	pathname.relative_path_from(base_path).to_s
-end
+module_paths = Chassis.make_relative(base_path, module_paths)
 
 Vagrant.configure("2") do |config|
 	# Set up potential providers.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,19 @@ module_paths.concat Dir.glob( base_path.to_s + "/extensions/*/modules" )
 # Convert to relative from Vagrantfile
 module_paths = Chassis.make_relative(base_path, module_paths)
 
+# Add global extensions, if they exist
+global_ext_path = File.join(Dir.home, ".chassis", "extensions")
+use_global_ext = Dir.exist?(global_ext_path) && ! Dir.empty?(global_ext_path)
+if use_global_ext
+	global_ext_modules = Dir.glob(global_ext_path + "/*/modules")
+	global_ext_modules.delete_if { |path|
+		ext_name = path.split("/")[-2]
+		# Search for the ext_name in the regular extensions
+		module_paths.include?("extensions/" + ext_name + "/modules")
+	}
+	global_ext_modules = Chassis.make_relative(global_ext_path, global_ext_modules)
+end
+
 Vagrant.configure("2") do |config|
 	# Set up potential providers.
 	config.vm.provider "virtualbox" do |vb|
@@ -84,6 +97,10 @@ Vagrant.configure("2") do |config|
 		## puppet.module_path    = module_paths
 		# Workaround:
 		machine_rel_module_paths = module_paths.map { |rel_path| "/vagrant/" + rel_path }
+		if use_global_ext
+			prefixed_global = global_ext_modules.map { |rel_path| "/vagrant/extensions/_global/" + rel_path }
+			machine_rel_module_paths.concat prefixed_global
+		end
 		puppet.options = "--modulepath " +  machine_rel_module_paths.join( ':' ).inspect
 
 		# Disable Hiera configuration file
@@ -113,6 +130,10 @@ Vagrant.configure("2") do |config|
 	# Set up synced folders.
 	synced_folders = CONF["synced_folders"].clone
 	synced_folders["."] = "/vagrant"
+
+	if use_global_ext
+		synced_folders[global_ext_path] = "/vagrant/extensions/_global"
+	end
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,8 +83,8 @@ Vagrant.configure("2") do |config|
 		# Broken due to https://github.com/mitchellh/vagrant/issues/2902
 		## puppet.module_path    = module_paths
 		# Workaround:
-		module_paths.map! { |rel_path| "/vagrant/" + rel_path }
-		puppet.options = "--modulepath " +  module_paths.join( ':' ).inspect
+		machine_rel_module_paths = module_paths.map { |rel_path| "/vagrant/" + rel_path }
+		puppet.options = "--modulepath " +  machine_rel_module_paths.join( ':' ).inspect
 
 		# Disable Hiera configuration file
 		puppet.options += " --hiera_config /dev/null"

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -30,6 +30,21 @@ To install the memcached extension you would do the following:
 3. `vagrant provision`.
 
 
+Globally installing extensions
+------------------------------
+
+In addition to per-project, extensions can be globally installed. This is useful
+for development tools that you want to apply to all your Chassis boxes, which
+aren't specific to any project.
+
+Chassis loads global extensions from ``~/.chassis/extensions`` in the same way
+that it loads project-specific extensions.
+
+If a project includes an extension of the same name in its ``extensions/``
+directory, the project's extension will be loaded instead of the
+globally-installed extension.
+
+
 Creating your own
 -----------------
 

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -21,7 +21,7 @@ as extensions, so extensions can be downloaded into this directory.
 
 
 Example: Installing The Memcached Extension
--------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To install the memcached extension you would do the following:
 

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -40,6 +40,12 @@ aren't specific to any project.
 Chassis loads global extensions from ``~/.chassis/extensions`` in the same way
 that it loads project-specific extensions.
 
+To install a global extension clone it into ``~/.chassis/extensions``. For
+example, if you'd like to make the mailhog extension global then you would run
+the following command in a terminal.
+
+``git clone https://github.com/Chassis/Mailhog ~/.chassis/extensions/mailhog``
+
 If a project includes an extension of the same name in its ``extensions/``
 directory, the project's extension will be loaded instead of the
 globally-installed extension.

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -29,13 +29,17 @@ module Chassis
 		return all if ! version
 
 		all.select { |extension|
-			config = get_extension_config(extension)
+			config = get_extension_config(extension, ext_dir)
 			config['version'] == version
 		}
 	end
 
 	def self.get_extensions(version = nil)
 		self.get_extensions_for_dir(@@extension_dir, version)
+	end
+
+	def self.get_global_extensions(version = nil)
+		self.get_extensions_for_dir(File.join(@@extension_dir, '_global'), version)
 	end
 
 	def self.load_config()

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -39,7 +39,13 @@ module Chassis
 	end
 
 	def self.get_global_extensions(version = nil)
-		self.get_extensions_for_dir(File.join(@@extension_dir, '_global'), version)
+		global = self.get_extensions_for_dir(File.join(@@extension_dir, '_global'), version)
+
+		# Remove extensions which are installed locally
+		regular = self.get_extensions(version)
+		global.reject { |item|
+			regular.include?( item )
+		}
 	end
 
 	def self.load_config()

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -20,8 +20,8 @@ module Chassis
 		end
 	end
 
-	def self.get_extensions(version = nil)
-		all = Dir.glob(@@extension_dir + '/*').map { |directory| File.basename( directory ) }
+	def self.get_extensions_for_dir(ext_dir, version = nil)
+		all = Dir.glob(ext_dir + '/*').map { |directory| File.basename( directory ) }
 
 		return all if ! version
 
@@ -29,6 +29,10 @@ module Chassis
 			config = get_extension_config(extension)
 			config['version'] == version
 		}
+	end
+
+	def self.get_extensions(version = nil)
+		self.get_extensions_for_dir(@@extension_dir, version)
 	end
 
 	def self.load_config()

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -6,11 +6,11 @@ module Chassis
 	@@extension_dir = File.join(@@dir, 'extensions')
 	@@extension_config = {}
 
-	def self.get_extension_config(extension)
+	def self.get_extension_config(extension, base_dir = @@extension_dir)
 		# Use cache if we can.
 		return @@extension_config[extension] if @@extension_config.key?(extension)
 
-		path = File.join(@@extension_dir, extension, 'chassis.yaml')
+		path = File.join(base_dir, extension, 'chassis.yaml')
 
 		begin
 			YAML.load_file(path)

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -23,6 +23,9 @@ module Chassis
 	def self.get_extensions_for_dir(ext_dir, version = nil)
 		all = Dir.glob(ext_dir + '/*').map { |directory| File.basename( directory ) }
 
+		# Remove dummy _global if found
+		all.delete("_global")
+
 		return all if ! version
 
 		all.select { |extension|

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -162,4 +162,13 @@ module Chassis
 
 		system("git clone %s %s --recursive" % [repo, Shellwords.escape(folder)] ) unless File.exist?( folder )
 	end
+
+	def self.make_relative(base, paths)
+		# Convert to relative from Vagrantfile
+		base = Pathname.new(base)
+		paths.map do |path|
+			pathname = Pathname.new(path)
+			pathname.relative_path_from(base).to_s
+		end
+	end
 end

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -64,6 +64,7 @@ chassis::wp { $config['hosts'][0]:
 	admin_password    => $config[admin][password],
 
 	extensions        => $extensions,
+	global_extensions => $global_extensions,
 
 	require => [
 		Class['chassis::php'],

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -4,7 +4,7 @@ import "/vagrant/extensions/*/chassis.pp"
 $config = sz_load_config()
 $extensions = sz_extensions('/vagrant/extensions')
 $loadable_extensions = sz_extensions('/vagrant/extensions', 2)
-$global_extensions = sz_extensions('/vagrant/extensions/_global', 2)
+$global_extensions = chassis_get_global_extensions()
 $php_extensions = [ 'curl', 'gd', 'mysql' ]
 
 if $global_extensions {

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -4,7 +4,14 @@ import "/vagrant/extensions/*/chassis.pp"
 $config = sz_load_config()
 $extensions = sz_extensions('/vagrant/extensions')
 $loadable_extensions = sz_extensions('/vagrant/extensions', 2)
+$global_extensions = sz_extensions('/vagrant/extensions/_global', 2)
 $php_extensions = [ 'curl', 'gd', 'mysql' ]
+
+if $global_extensions {
+	class { $global_extensions:
+		config => $config,
+	}
+}
 
 if $loadable_extensions {
 	class { $loadable_extensions:

--- a/puppet/modules/chassis/lib/puppet/parser/functions/sz_extensions.rb
+++ b/puppet/modules/chassis/lib/puppet/parser/functions/sz_extensions.rb
@@ -5,6 +5,6 @@ module Puppet::Parser::Functions
 		directory = args[0]
 		version = args.length > 1 ? args[1].to_i : nil
 
-		Chassis.get_extensions(version)
+		Chassis.get_extensions_for_dir(directory, version)
 	end
 end

--- a/puppet/modules/chassis/lib/puppet/parser/functions/sz_extensions.rb
+++ b/puppet/modules/chassis/lib/puppet/parser/functions/sz_extensions.rb
@@ -7,4 +7,9 @@ module Puppet::Parser::Functions
 
 		Chassis.get_extensions_for_dir(directory, version)
 	end
+
+	newfunction(:chassis_get_global_extensions, :type => :rvalue) do |args|
+		version = args[0]
+		Chassis.get_global_extensions(version)
+	end
 end

--- a/puppet/modules/chassis/manifests/wp.pp
+++ b/puppet/modules/chassis/manifests/wp.pp
@@ -15,6 +15,7 @@ define chassis::wp (
 	$network = false,
 
 	$extensions = [],
+	$global_extensions = [],
 ) {
 	$subdomains = ( $network == 'subdomains' )
 	if ( $network ) {

--- a/puppet/modules/chassis/templates/local-config-extensions.php.erb
+++ b/puppet/modules/chassis/templates/local-config-extensions.php.erb
@@ -2,6 +2,13 @@
 
 // This is generated automatically by Puppet. Edit at your own risk.
 
+<%- @global_extensions.each do |extension| -%>
+<%- path = "__DIR__ . '/extensions/_global/" + extension + "/local-config.php'" -%>
+if ( file_exists( <%= path %> ) )
+	require_once <%= path %>;
+
+<%- end -%>
+
 <%- @extensions.each do |extension| -%>
 <%- path = "__DIR__ . '/extensions/" + extension + "/local-config.php'" -%>
 if ( file_exists( <%= path %> ) )


### PR DESCRIPTION
Fixes #574.

To test: create a `~/.chassis/extensions` directory, and clone an extension (e.g. MailHog) into it. Then provision your box, and note that MailHog is provisioned on it.

Remaining items:
* [x] Write documentation