### PR TITLE
Revert `wp-includes/version.php` to the correct revision from 5.0 release

### DIFF
--- a/wp/wp-includes/version.php
+++ b/wp/wp-includes/version.php
@@ -4,7 +4,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '5.0.1-alpha-43972';
+$wp_version = '5.0';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
While every other file from 5.0 is correct as of #589, this `version` string is not the same, well, _version_ as in the packaged 5.0 release. Changing this string makes the WordPress install contained within Chassis 100% congruent with 5.0.