### PR TITLE
Update apt automatically

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -20,12 +20,10 @@ if $loadable_extensions {
 }
 
 class { 'apt':
-  update => {
-	  frequency => 'weekly',
-  },
+	update => {
+		frequency => 'weekly',
+	},
 }
-
-include apt
 
 class { 'chassis::php':
 	extensions => $php_extensions,

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -19,6 +19,12 @@ if $loadable_extensions {
 	}
 }
 
+class { 'apt':
+  update => {
+	  frequency => 'weekly',
+  },
+}
+
 include apt
 
 class { 'chassis::php':


### PR DESCRIPTION
Fixes #582.

Although the order of this looks weird, if this is added after `include apt` the provisioning fails!