### PR TITLE
Bump the PHP version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ synced_folders:
 
 # PHP version
 # Values: 5.6, 7.0, 7.1, 7.2, 7.3 (or 5.6.30)
-php: 7.2
+php: 7.3
 
 # VirtualBox-specific customisations.
 virtualbox:


### PR DESCRIPTION
This "fixes" #634. It might not be an "issue" as such but I know I've had a bunch of people DMing me about all the Site Health checks and thinking it's a Chassis issue when it's not...but it kinda is according to devs.

<img width="1430" alt="Site_Health_Status_9_Chassis_Site__WordPress_2019-06-01_19-54-03" src="https://user-images.githubusercontent.com/1377956/58747060-18af6c80-84a9-11e9-89da-122c02da7e21.png">

Maybe I should make yet another extension called `Site Health` that devs can use that installs all the extensions to get the `Site Health` stuff to 100%? I'm open to any and all feedback. Power in numbers y'all! 💯
