### PR TITLE
Pass synced folders to guest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,6 +68,14 @@ Vagrant.configure("2") do |config|
 			vb.memory = CONF['virtualbox']['memory'] if CONF['virtualbox']['memory']
 			vb.cpus = CONF['virtualbox']['cpus'] if CONF['virtualbox']['cpus']
 		end
+
+		# Pass synched folders to guest
+		full_synched = {}
+		synced_folders.each do |from, to|
+			full_from = File.realpath from, base_path.to_s
+			full_synched[ to ] = full_from
+		end
+		vb.customize [ "guestproperty", "set", :id, "/Chassis/synced_folders", JSON.dump( full_synched ), "--flags", "TRANSIENT,RDONLYGUEST" ]
 	end
 
 	# We <3 Ubuntu LTS

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,6 +49,14 @@ if use_global_ext
 end
 
 Vagrant.configure("2") do |config|
+	# Set up synced folders.
+	synced_folders = CONF["synced_folders"].clone
+	synced_folders["."] = "/vagrant"
+
+	if use_global_ext
+		synced_folders[global_ext_path] = "/vagrant/extensions/_global"
+	end
+
 	# Set up potential providers.
 	config.vm.provider "virtualbox" do |vb|
 		# Use linked clones to preserve disk space.
@@ -130,13 +138,6 @@ Vagrant.configure("2") do |config|
 		]
 	end
 
-	# Set up synced folders.
-	synced_folders = CONF["synced_folders"].clone
-	synced_folders["."] = "/vagrant"
-
-	if use_global_ext
-		synced_folders[global_ext_path] = "/vagrant/extensions/_global"
-	end
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -146,6 +146,11 @@ Vagrant.configure("2") do |config|
 		]
 	end
 
+	# Export necessary constants to the VM
+	config.vm.provision "set_constants",
+		type: :shell,
+		path: "puppet/export-constants.sh",
+		run: "always"
 
 	# Ensure that WordPress can install/update plugins, themes and core
 	mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,13 +69,13 @@ Vagrant.configure("2") do |config|
 			vb.cpus = CONF['virtualbox']['cpus'] if CONF['virtualbox']['cpus']
 		end
 
-		# Pass synched folders to guest
-		full_synched = {}
+		# Pass synced folders to guest
+		full_synced = {}
 		synced_folders.each do |from, to|
 			full_from = File.realpath from, base_path.to_s
-			full_synched[ to ] = full_from
+			full_synced[ to ] = full_from
 		end
-		vb.customize [ "guestproperty", "set", :id, "/Chassis/synced_folders", JSON.dump( full_synched ), "--flags", "TRANSIENT,RDONLYGUEST" ]
+		vb.customize [ "guestproperty", "set", :id, "/Chassis/synced_folders", JSON.dump( full_synced ), "--flags", "TRANSIENT,RDONLYGUEST" ]
 	end
 
 	# We <3 Ubuntu LTS

--- a/puppet/export-constants.sh
+++ b/puppet/export-constants.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+touch /etc/chassis-constants
+
+echo -n "{" > /etc/chassis-constants
+
+# Export synced folders configuration to $CHASSIS_SYNCED_FOLDERS
+synced_folders=`VBoxControl --nologo guestproperty get /Chassis/synced_folders 2>/dev/null`
+if [[ $synced_folders == "Value: "* ]]; then
+	echo -n "\"synced_folders\":${synced_folders:7}" >> /etc/chassis-constants
+fi
+
+echo -n "}" >> /etc/chassis-constants
+chmod a+r /etc/chassis-constants


### PR DESCRIPTION
Creates a new `/etc/chassis-constants` JSON file (world-readable) which contains a `synced_folders` object with the host's paths.

Fixes #637.