### PR TITLE
Prepare for the extensions for Bionic Beaver

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,9 @@
 # - project/config.local.yaml          (global overrides)
 # - project/config.yaml                 (global defaults)
 
+# Add a version for Chassis for when we upgrade Ubuntu distributions. We're currently on version 2.1: https://github.com/Chassis/Chassis/releases/tag/2.1
+version: 2.1
+
 # Domain names to use for Vagrant
 #
 # The first name will be used as the machine's name, subsequent names will be

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -177,24 +177,31 @@ module Chassis
 			repo = extension
 		end
 
+		renamed_extensions = Array.new
 		# We need to add a version to allow for a seamless upgrade to Bionic Beaver.
 		if config["version"] >= 3
 			# Check for existing extensions that have a hyphen and remove them.
 			old_extensions = Dir.glob(@@dir + '/extensions/*')
 			old_extensions.each { |extension|
-				next unless extension.include? "-"
-					# Delete the old extension if it has a hyphen in it.
-					FileUtils.remove_dir(extension)
-					new_extension = extension.gsub(/-/, '_')
-					puts "We've renamed #{extension} to #{new_extension} as hyphens aren't allowed in Puppet: https://puppet.com/docs/puppet/5.4/lang_reserved.html#classes-and-defined-resource-types"
-					puts "If you have #{extension} in one of your yaml configuration files we would recommend altering it to #{new_extension}."
-				end
-		    }
+			next unless extension.include? "-"
+				# Delete the old extension if it has a hyphen in it.
+				FileUtils.remove_dir(extension)
+				new_extension = extension.gsub(/-/, '_')
+				renamed_extensions << "- #{extension} to #{new_extension}"
+			}
 		    # Puppet have taken a hard stance on not allowing hyphens in class names.
 		    folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/\.git$/, '').gsub(/-/, '_').downcase
 		else
 		    # Leave extensions as they were for Xenial and below for backwards compatibility.
 		    folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/\.git$/, '').downcase
+		end
+
+		if ! renamed_extensions.empty?
+			puts("\e[33mWe're renaming the following extensions:")
+			renamed_extensions.each {|extension|
+				puts extension
+			}
+			puts("\e[0m")
 		end
 
 		system("git clone %s %s --recursive" % [repo, Shellwords.escape(folder)] ) unless File.exist?( folder )

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -187,6 +187,7 @@ module Chassis
 					FileUtils.remove_dir(extension)
 					new_extension = extension.gsub(/-/, '_')
 					puts "We've renamed #{extension} to #{new_extension} as hyphens aren't allowed in Puppet: https://puppet.com/docs/puppet/5.4/lang_reserved.html#classes-and-defined-resource-types"
+					puts "If you have #{extension} in one of your yaml configuration files we would recommend altering it to #{new_extension}."
 				end
 		    }
 		    # Puppet have taken a hard stance on not allowing hyphens in class names.

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -186,7 +186,7 @@ module Chassis
 					# Delete the old extension if it has a hyphen in it.
 					FileUtils.remove_dir(extension)
 					new_extension = extension.gsub(/-/, '_')
-					puts "We've upgraded #{extension} to #{new_extension}"
+					puts "We've renamed #{extension} to #{new_extension} as hyphens aren't allowed in Puppet: https://puppet.com/docs/puppet/5.4/lang_reserved.html#classes-and-defined-resource-types"
 				end
 		    }
 		    # Puppet have taken a hard stance on not allowing hyphens in class names.

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -178,7 +178,7 @@ module Chassis
 		end
 
 		# We need to add a version to allow for a seamless upgrade to Bionic Beaver.
-		if config["version"] = 3
+		if config["version"] >= 3
 			# Check for existing extensions that have a hyphen and remove them.
 			old_extensions = Dir.glob(@@dir + '/extensions/*')
 			old_extensions.each { |extension|
@@ -189,7 +189,7 @@ module Chassis
 					puts "We've upgraded #{extension} to #{new_extension}"
 				end
 		    }
-		    # Puppet have taken a hard stance on not allowing hypens in class names.
+		    # Puppet have taken a hard stance on not allowing hyphens in class names.
 		    folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/.git$/, '').gsub(/-/, '_').downcase
 		else
 		    # Leave extensions as they were for Xenial and below for backwards compatibility.

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -177,7 +177,24 @@ module Chassis
 			repo = extension
 		end
 
-		folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/.git$/, '').downcase
+		# We need to add a version to allow for a seamless upgrade to Bionic Beaver.
+		if config["version"] = 3
+			# Check for existing extensions that have a hyphen and remove them.
+			old_extensions = Dir.glob(@@dir + '/extensions/*')
+			old_extensions.each { |extension|
+				if extension.include? "-"
+					# Delete the old extension if it has a hyphen in it.
+					FileUtils.remove_dir(extension)
+					new_extension = extension.gsub(/-/, '_')
+					puts "We've upgraded #{extension} to #{new_extension}"
+				end
+		    }
+		    # Puppet have taken a hard stance on not allowing hypens in class names.
+		    folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/.git$/, '').gsub(/-/, '_').downcase
+		else
+		    # Leave extensions as they were for Xenial and below for backwards compatibility.
+		    folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/.git$/, '').downcase
+		end
 
 		system("git clone %s %s --recursive" % [repo, Shellwords.escape(folder)] ) unless File.exist?( folder )
 	end

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -182,7 +182,7 @@ module Chassis
 			# Check for existing extensions that have a hyphen and remove them.
 			old_extensions = Dir.glob(@@dir + '/extensions/*')
 			old_extensions.each { |extension|
-				if extension.include? "-"
+				next unless extension.include? "-"
 					# Delete the old extension if it has a hyphen in it.
 					FileUtils.remove_dir(extension)
 					new_extension = extension.gsub(/-/, '_')

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -150,6 +150,16 @@ module Chassis
 	end
 
 	def self.install_extensions(config)
+		if config["version"] >= 3
+			# Warn about old extensions.
+			config["extensions"].each do |extension|
+				if extension.include? "-"
+					new_extension = extension.gsub(/-/, '_')
+					puts("\e[33mPlease change #{extension} to #{new_extension} in your yaml configuration file. \e[0m")
+				end
+			end
+		end
+
 		# Install extensions listed in config
 		if config["extensions"]
 			config["extensions"].each { |ext| self.install_extension(ext) }


### PR DESCRIPTION
Fixes #657.

I've tested this with https://github.com/Chassis/Query_Monitor as it's the only extension I've prepared for Bionic Beaver.

A current installation with `query-monitor` installed in `extensions/query-monitor` (or has `- query-monitor` in a yaml file) remains untouched.

When I add `version: 3.0` to a custom yaml file the `extensions/query-monitor` extension is remove and cloned recursively into `extensions/query_monitor` as expected.

Once this is merged we will need to update the extensions that contain underscores in the repos and classes. I'll open issues upstream to in those extensions.