### PR TITLE
Set nginx fastcgi_buffer config to stop 502 errors

### DIFF
--- a/puppet/modules/chassis/templates/site.nginx.conf.erb
+++ b/puppet/modules/chassis/templates/site.nginx.conf.erb
@@ -8,6 +8,8 @@ server {
 	fastcgi_split_path_info ^(.+\.php)(/.+)$;
 	fastcgi_index index.php;
 	fastcgi_read_timeout 900;
+	fastcgi_buffers 16 16k; 
+	fastcgi_buffer_size 32k;
 
 	proxy_connect_timeout       300;
 	proxy_send_timeout          300;


### PR DESCRIPTION
A lot of my admin ajax scripts (such as adding a custom attribute in woocommerce) were giving a 502 error. Having dug into this issue I came across https://stackoverflow.com/a/23845727/380054 which fixed the issue for me.

If we do decide to go with this we may want to have a read of: https://gist.github.com/magnetikonline/11312172#determine-fastcgi-response-sizes it seems that a one size fits all solution may not be the best option, however sensible defaults with documentation on how to change these values to suit is perhaps better than broken environments.