### PR TITLE
Add new line

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -142,4 +142,5 @@ if ( ! file_exists( ABSPATH . 'wp-settings.php' ) ) {
 	echo '<h1>WordPress is missing.</h1>';
 	die(1);
 }
+
 require_once( ABSPATH . 'wp-settings.php' );


### PR DESCRIPTION
We need a new line for the WP-CLI check that's done with regex. I'm using the trunk version of WP-CLI to get this error so it's going to be something we hit in the future so let's future proof it.

Fixes #660.