### PR TITLE
Fix nginx logging

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -166,7 +166,7 @@ Vagrant.configure("2") do |config|
 	mount_opts = CONF['nfs'] ? [] : ["dmode=777","fmode=777"]
 
 	synced_folders.each do |from, to|
-		config.vm.synced_folder from, to, :mount_options => mount_opts, :nfs => CONF['nfs']
+		config.vm.synced_folder from, to, :mount_options => mount_opts, :nfs => CONF['nfs'], :group => 'www-data', :owner => 'www-data'
 
 		# Automatically use bindfs if we can.
 		if CONF['nfs'] && Vagrant.has_plugin?("vagrant-bindfs")

--- a/puppet/modules/chassis/templates/nginx.conf.erb
+++ b/puppet/modules/chassis/templates/nginx.conf.erb
@@ -1,4 +1,3 @@
-user www-data;
 worker_processes 4;
 pid /var/run/nginx.pid;
 


### PR DESCRIPTION
Fixes #662. 

`nginx -t` showed the warning:
>[warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1

So I removed that as well.