### PR TITLE
Remove extra_hosts for single sites

### DIFF
--- a/puppet/modules/chassis/manifests/site.pp
+++ b/puppet/modules/chassis/manifests/site.pp
@@ -15,7 +15,7 @@ define chassis::site (
 	$sitename       = 'Chassis Site',
 ) {
 	$extra_hosts = join($hosts, ' ')
-	$server_name = rstrip("${name}")
+	$server_name = rstrip($name)
 	file { $wpdir:
 		ensure => directory
 	}

--- a/puppet/modules/chassis/manifests/site.pp
+++ b/puppet/modules/chassis/manifests/site.pp
@@ -15,7 +15,7 @@ define chassis::site (
 	$sitename       = 'Chassis Site',
 ) {
 	$extra_hosts = join($hosts, ' ')
-	$server_name = rstrip("${name} ${extra_hosts}")
+	$server_name = rstrip("${name}")
 	file { $wpdir:
 		ensure => directory
 	}


### PR DESCRIPTION
Fixes #672. 

This changes the `server` block in Nginx from:
`server_name vagrant.local vagrant.local *.ngrok.io;`
to
`server_name vagrant.local *.ngrok.io;`