### PR TITLE
Add PHP 7.4 support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -107,7 +107,7 @@ synced_folders:
 #  - git@github.com:Chassis/memcache.git
 
 # PHP version
-# Values: 5.6, 7.0, 7.1, 7.2, 7.3 (or 5.6.30)
+# Values: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 (or 5.6.30)
 php: 7.3
 
 # Maximum file upload size. This will set post_max_size and upload_max_filesize in PHP and client_max_body_size in Nginx.

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -91,7 +91,8 @@ class chassis::php (
 			'7.0',
 			'7.1',
 			'7.2',
-			'7.3': {
+			'7.3',
+			'7.4': {
 				package { [ "php${name}-fpm", "php${name}-cli", "php${name}-common" ]:
 					ensure => absent,
 				}
@@ -106,27 +107,32 @@ class chassis::php (
 
 	case $short_ver {
 		'5.6': {
-			remove_php_fpm { [ '7.0', '7.1', '7.2', '7.3' ]:
+			remove_php_fpm { [ '7.0', '7.1', '7.2', '7.3', '7.4' ]:
 				notify => Service["${php_package}-fpm"],
 			}
 		}
 		'7.0': {
-			remove_php_fpm { [ '5.6', '7.1', '7.2', '7.3' ]:
+			remove_php_fpm { [ '5.6', '7.1', '7.2', '7.3', '7.4' ]:
 				notify => Service["${php_package}-fpm"],
 			}
 		}
 		'7.1': {
-			remove_php_fpm { [ '5.6', '7.0', '7.2', '7.3' ]:
+			remove_php_fpm { [ '5.6', '7.0', '7.2', '7.3', '7.4' ]:
 				notify => Service["${php_package}-fpm"],
 			}
 		}
 		'7.2': {
-			remove_php_fpm { [ '5.6', '7.0', '7.1', '7.3' ]:
+			remove_php_fpm { [ '5.6', '7.0', '7.1', '7.3', '7.4' ]:
 				notify => Service["${php_package}-fpm"],
 			}
 		}
 		'7.3': {
-			remove_php_fpm { [ '5.6', '7.0', '7.1', '7.2' ]:
+			remove_php_fpm { [ '5.6', '7.0', '7.1', '7.2', '7.4' ]:
+				notify => Service["${php_package}-fpm"],
+			}
+		}
+		'7.4': {
+			remove_php_fpm { [ '5.6', '7.0', '7.1', '7.2', '7.3' ]:
 				notify => Service["${php_package}-fpm"],
 			}
 		}


### PR DESCRIPTION
Fixes #686. 

The ppa we are using has been shipping 7.4 builds for a while now. Let's merge this in so people can start testing, fixing and developing on 7.4.