### PR TITLE
Exclude parent directory from hyphenated class check

### DIFF
--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -197,17 +197,19 @@ module Chassis
 			# Check for existing extensions that have a hyphen and remove them.
 			old_extensions = Dir.glob(@@dir + '/extensions/*')
 			old_extensions.each { |extension|
-			next unless extension.include? "-"
+			# Remove @@dir before "-" include check in case of hyphenated parent directories.
+			next unless extension.gsub(@@dir, '').include? "-"
 				# Delete the old extension if it has a hyphen in it.
 				FileUtils.remove_dir(extension)
-				new_extension = extension.gsub(/-/, '_')
+				# Swap "-" for "_" in the non-parent-directory part of the path.
+				new_extension = @@dir + extension.gsub(@@dir, '').gsub(/-/, '_')
 				renamed_extensions << "- #{extension} to #{new_extension}"
 			}
-		    # Puppet have taken a hard stance on not allowing hyphens in class names.
-		    folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/\.git$/, '').gsub(/-/, '_').downcase
+			# Puppet have taken a hard stance on not allowing hyphens in class names.
+			folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/\.git$/, '').gsub(/-/, '_').downcase
 		else
-		    # Leave extensions as they were for Xenial and below for backwards compatibility.
-		    folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/\.git$/, '').downcase
+			# Leave extensions as they were for Xenial and below for backwards compatibility.
+			folder = @@dir + '/extensions/' + extension.split('/').last.gsub(/\.git$/, '').downcase
 		end
 
 		if ! renamed_extensions.empty?


### PR DESCRIPTION
A parent directory (Chassis checkout repo root) such as `.../my-vm` has no impact on Puppet's new stricter rules around using `-` instead of `-` in class names, but if Chassis was checked out into a hyphenated directory, our logic previously detected and warned on the "-" in that parent directory even if no hyphenated Puppet class was present.

If we do not exclude the parent directory from the string when testing for or, more critically, creating new correct path strings, we end up trying to clone the repositories into a non-existent directory path.

Fixes #689