### PR TITLE
Remove chassis-updated after provisioning

### DIFF
--- a/puppet/preparebox.sh
+++ b/puppet/preparebox.sh
@@ -1,1 +1,4 @@
-# This is a placeholder file in case we need to run other scripts for the base box
+# Remove anything used during provisioning which needs to be re-done for each
+# individual box.
+
+rm /etc/chassis-updated


### PR DESCRIPTION
Fixes #720.

This could be a temporary fix if we can come up with a time-based solution (#582) instead.