### PR TITLE
Notify apt::update when removing PHP

### DIFF
--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -98,11 +98,13 @@ class chassis::php (
 			'7.4': {
 				package { [ "php${name}-fpm", "php${name}-cli", "php${name}-common" ]:
 					ensure => absent,
+					notify => Class['apt::update'],
 				}
 			}
 			default: {
 				package { [ 'php5-fpm', 'php5-cli', 'php5-common' ]:
 					ensure => absent,
+					notify => Class['apt::update'],
 				}
 			}
 		}


### PR DESCRIPTION
This helps puppet know when previously installed packages need to be reinstalled. Fixes chassis/v8js#34