### PR TITLE
Revert "Update apt weekly"

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -18,12 +18,7 @@ if $loadable_extensions {
 		config => $config,
 	}
 }
-
-class { 'apt':
-	update => {
-		frequency => 'weekly',
-	},
-}
+include apt
 
 class { 'chassis::php':
 	extensions  => $php_extensions,


### PR DESCRIPTION
Reverts Chassis/Chassis#732

There's an extension incompatibility that we need to track down first before we can do this.