### PR TITLE
Use cloud publish command

### DIFF
--- a/buildbox.sh
+++ b/buildbox.sh
@@ -45,6 +45,6 @@ vagrant package --output "chassis-$NOW.box"
 
 echo "\n\033[0;32mCommencing upload of the new Chassis box to Vagrant Cloud..."
 
-vagrant cloud provider upload chassis/chassis virtualbox $VERSION chassis-$NOW.box
+vagrant cloud publish chassis/chassis $VERSION virtualbox chassis-$NOW.box --release 
 
 echo "\n\033[0;32mUpload complete!"


### PR DESCRIPTION
The cloud provider upload command just didn't work for me, I think there may be some steps that the publish command does on vagrant cloud that the direct upload one doesn't such as creating the release. The direct upload command may require the version to be created already on vagrant cloud.