### PR TITLE
Remove text/html mime type

### DIFF
--- a/puppet/modules/chassis/templates/nginx.conf.erb
+++ b/puppet/modules/chassis/templates/nginx.conf.erb
@@ -41,7 +41,7 @@ http {
 	gzip_min_length 1100;
 	gzip_buffers 16 8k;
 	gzip_vary on;
-	gzip_types text/plain text/html text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+	gzip_types text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
 	##
 	# Virtual Host Configs


### PR DESCRIPTION
Fixes #767. I've confirmed this by deleting the `error.log` and running a `vagrant destroy -f` and `vagrant up`.

>vagrant@vagrant:~$ sudo nginx -t
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful