### PR TITLE
Use chassis official extension in config docs

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -459,7 +459,7 @@ Extension names can be specified in one of three ways:
 
    extensions:
       - Tester
-      - javorszky/chassis-openssl
+      - chassis/chassis-openssl
       - https://bitbucket.org/some/example.git
 
 You can also remove extensions that you have previously installed. All configuration files will be remove from your Chassis server.


### PR DESCRIPTION
Because we actually have an official openssl extension, we should remove javorsky's URL from the docs. It can be confusing if people are using search on the docs and get this URL when searching `openssl`.

I've opted to switch to our official openssl extension here, but happy to use any other external repository that doesn't clash with anything we offer officially.