### PR TITLE
Move non-*.local domain warning to run only on "up" and "provision"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,8 +70,8 @@ Vagrant.configure("2") do |config|
 					deprecated_extensions << "Please change #{extension} to #{new_extension} in your yaml configuration file.\n"
 				end
 			end
+			trigger.warn = "#{deprecated_extensions}"
 		end
-		trigger.warn = "#{deprecated_extensions}"
 	end
 
 	# Show a warning that non-*.local domains will not automatically resolve.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,6 +72,13 @@ Vagrant.configure("2") do |config|
 			end
 		end
 		trigger.warn = "#{deprecated_extensions}"
+	end
+
+	# Show a warning that non-*.local domains will not automatically resolve.
+	config.trigger.after [ :provision, :up ] do |trigger|
+		if ! CONF['hosts'][0].include?('.local')
+			trigger.info = "\n\e[33mWARNING: The hosts URL does not contain .local.\nYou will need to edit your hosts file for this URL to resolve.\e[0m"
+		end
 	 end
 
 	# Set up synced folders.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -276,9 +276,6 @@ be redirected by WordPress depending on your configuration or plugins.
    them automatically, so make sure to add these to your hosts file on your
    computer (not inside the virtual machine).
 
-   A warning is displayed if a non-`.local` host domain is used, which can be
-   turned off using the config option `suppress_hosts_warning: true`.
-
    If you need to find out the IP address of your machine, run ``vagrant ssh``
    to connect, then inside the box run ``ifconfig eth1`` and look for the line
    starting with ``inet addr:``.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -276,6 +276,9 @@ be redirected by WordPress depending on your configuration or plugins.
    them automatically, so make sure to add these to your hosts file on your
    computer (not inside the virtual machine).
 
+   A warning is displayed if a non-`.local` host domain is used, which can be
+   turned off using the config option `suppress_hosts_warning: true`.
+
    If you need to find out the IP address of your machine, run ``vagrant ssh``
    to connect, then inside the box run ``ifconfig eth1`` and look for the line
    starting with ``inet addr:``.

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -166,7 +166,7 @@ module Chassis
 			config["paths"]["wp"] = config["wpdir"]
 		end
 
-		if ! config["hosts"][0].include?(".local")
+		if ! config["hosts"][0].include?(".local") and config['suppress_hosts_warning'] != true
 			puts "\e[33mWARNING: The hosts URL does not contain .local. You will need to edit your hosts file for this URL to resolve.\e[0m"
 		end
 

--- a/puppet/chassis.rb
+++ b/puppet/chassis.rb
@@ -166,10 +166,6 @@ module Chassis
 			config["paths"]["wp"] = config["wpdir"]
 		end
 
-		if ! config["hosts"][0].include?(".local") and config['suppress_hosts_warning'] != true
-			puts "\e[33mWARNING: The hosts URL does not contain .local. You will need to edit your hosts file for this URL to resolve.\e[0m"
-		end
-
 		# Set up the paths as needed
 		config["mapped_paths"] = {}
 		base = config["paths"]["base"] = File.expand_path(config["paths"]["base"], @@dir)


### PR DESCRIPTION
This is a valid configuration choice and we should not continually yell at users who have opted to go the hostsupdater or manual hosts file modification route.

Moved logic to Vagrantfile to permit it only running on certain actions, rather than every time you SSH. This removes the need for a custom configuration option entirely.

Warning now displays as follows:

![image](https://user-images.githubusercontent.com/442115/85172831-d980c480-b23f-11ea-97c4-09482e0d4c8b.png)

Original description:

> I do not love the name of this config property, and would accept suggestions for other alternatives.
>
> I also considered suppressing it if `hostsupdater` is `true`, but @BronsonQuick shot that one down :)