### PR TITLE
Improve gitignore to avoid dirty working directory when using common extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /local-config-hosts.php
 /local-config-tester.php
 /sql-dump-*.sql
+chassis-backup.sql
 /db-sync
 /content
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ wp-cli.yml
 *.box
 /xhgui
 /*.cert
+/*.key
 /phpmemcachedadmin
 /webgrind
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /local-config-db.php
 /local-config-extensions.php
 /local-config-hosts.php
+/local-config-tester.php
 /sql-dump-*.sql
 /db-sync
 /content


### PR DESCRIPTION
This extends the work @johnbillion did to fix #482 to ignore a few additional common files which may be present in the root directory of a Chassis checkout.