### PR TITLE
Improve mobile styling of Chassis site; reapply style.css

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -27,9 +27,25 @@ div.body p {
 	line-height: 1.5;
 }
 
+div.sphinxsidebarwrapper {
+	display: flex;
+	flex-direction: column;
+}
+div.sphinxsidebarwrapper > * {
+	order: 3;
+}
+div.sphinxsidebarwrapper .blurb {
+	order: 1;
+}
+div.sphinxsidebarwrapper p.logo {
+	order: 0;
+}
+#searchbox {
+	order: 2;
+}
+
 div.sphinxsidebarwrapper p.blurb {
 	margin: 1em 0;
-	text-align: center;
 }
 
 div.sphinxsidebar h3,
@@ -52,4 +68,32 @@ div.sphinxsidebar a {
 
 div.footer a {
 	border: none;
+}
+
+div.body {
+	min-width: unset;
+}
+
+@media screen and (max-width: 875px) {
+	div.body h1 {
+		margin: 0.5em 0 1em;
+	}
+	body {
+		padding: 20px;
+	}
+	div.sphinxsidebar {
+		width: unset;
+		margin: 50px -20px -20px;
+	}
+	div.sphinxsidebar p.logo {
+		display: block;
+		margin: -18px -20px 0;
+	}
+	.toctree-wrapper {
+		font-size: 0.9em;
+	}
+}
+
+.toctree-wrapper {
+	word-wrap: break-word;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,4 +295,4 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 def setup(app):
-    app.add_stylesheet('_static/style.css')
+    app.add_stylesheet('style.css')


### PR DESCRIPTION
- Style.css was not being included due to a path error in the python file
- Mobile styling was sub-optimal due to margin and max-width issues in the base theme

This PR improves the overall look and feel of the docs site by reapplying the custom style overrides file, and further adjusting individual styles to improve display on small viewports

Before:
![image](https://user-images.githubusercontent.com/442115/86935751-2fdc7700-c10b-11ea-8975-20842af30ea6.png) ![image](https://user-images.githubusercontent.com/442115/86935813-41be1a00-c10b-11ea-8747-974b4593f8c6.png)

After:
![image](https://user-images.githubusercontent.com/442115/86935864-4da9dc00-c10b-11ea-8b8e-d7ae73c0362b.png) ![image](https://user-images.githubusercontent.com/442115/86935957-6619f680-c10b-11ea-98ad-40fa074408df.png)


This also reinstates the Chassis logo in the footer at small breakpoints (it looks good!), and also moves the search box directly below the Blurb in the footer (mobile) or sidebar (desktop) for utility & visibility