### PR TITLE
Use correct hostsupdater options remove_on_suspend

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -144,7 +144,7 @@ Vagrant.configure("2") do |config|
 		else
 			config.vm.network :private_network, ip: CONF['ip']
 			# IP will not change regularly, so don't remove it on halt/suspend.
-			config.hostsupdater.resume_on_suspend = false
+			config.hostsupdater.remove_on_suspend = false
 		end
 		if CONF['hosts'].count > 1
 			config.hostsupdater.aliases = CONF['hosts']


### PR DESCRIPTION
If I use the vagrant-hostsupdater plugin and configure a static IP address for my machine, when starting a Chassis instance, I see the following error:

```
There are errors in the configuration of this machine. Please fix the following errors and try again:

VagrantPlugins::HostsUpdater::Config:
* The following settings shouldn't exist: resume_on_suspend
```
The documentation for [vagrant-hostsupdater](https://github.com/agiledivider/vagrant-hostsupdater#keeping-host-entries-after-suspendhalt) indicates that the correct option is remove_on_suspend, this change ensures that the correct option is used for vagrant-hostsupdater.