### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -108,7 +108,7 @@ synced_folders:
 #  - git@github.com:Chassis/memcache.git
 
 # PHP version
-# Values: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 (or 5.6.30)
+# Values: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0 (or 5.6.30)
 php: 7.4
 
 # Maximum file upload size. This will set post_max_size and upload_max_filesize in PHP and client_max_body_size in Nginx.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -79,7 +79,7 @@ PHP Version
 
 .. py:data:: php
 
-PHP 7.2 is included with Chassis by default, plus we register the additional
+PHP 7.4 is included with Chassis by default, plus we register the additional
 repositories for the other versions. We don't download them all automatically,
 to avoid extra download times, but switching is still pretty fast as we
 pre-register the APT repositories.
@@ -91,7 +91,7 @@ To switch to 5.6 for example:
 
 You can use either a two-part version (``5.6``) or a three-part version
 (``5.6.1``) if you want to pick specifc versions. We support any version between
-5.6.0 and 7.3.x.
+5.6.0 and 8.0.x.
 
 --------------------
 PHP File Upload Size

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -49,7 +49,7 @@ class chassis::php (
 	$prefixed_extensions = prefix( $extensions, "${php_package}-" )
 
 	# Any array of all the versions of php that we support.
-	$php_versions = [ '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
+	$php_versions = [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
 
 	# Work out which version of php we should remove if we've swapped versions.
 	$php_versions_to_remove = delete( $php_versions, $short_ver )


### PR DESCRIPTION
Fixes #835. I wanted to get this in quickly for people who use Chassis with WordPress core dev. This will help people who want to start working on PHP 8.0 support in core.

<img width="1552" alt="PHP_8 0 0rc1_-_phpinfo_2020-10-12_08-48-46" src="https://user-images.githubusercontent.com/1377956/95692281-03834a00-0c68-11eb-8400-9089583af504.png">
<img width="566" alt="chassis__vagrantvagrant___ssh__vagrant_ssh__20057_2020-10-12_08-48-19" src="https://user-images.githubusercontent.com/1377956/95692283-04b47700-0c68-11eb-946e-0257ebc59e20.png">
