### PR TITLE
Change site to website

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ hostsupdater: yes
 
 # Site Configuration
 # (When overriding, include all values)
-site:
+website:
     name: Chassis Site
 
 # IP address to use on the private network

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -449,13 +449,13 @@ To find the slug just copy and paste the plugins slug from your browsers. For ex
 Site Title
 ----------
 
-.. py:data:: site
+.. py:data:: website
 
 You can customize the title Chassis uses when installing your local WordPress site.
 
 .. code-block:: yaml
 
-   site:
+   website:
       name: My Local WordPress Site
 
 ----------

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -79,7 +79,7 @@ chassis::wp { $config['hosts'][0]:
 	admin_email       => $config[admin][email],
 	admin_password    => $config[admin][password],
 	machine_name      => $config[machine_name],
-  sitename          => $config[website][name],
+	sitename          => $config[website][name],
 
 	extensions        => $extensions,
 	global_extensions => $global_extensions,

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -79,6 +79,7 @@ chassis::wp { $config['hosts'][0]:
 	admin_email       => $config[admin][email],
 	admin_password    => $config[admin][password],
 	machine_name      => $config[machine_name],
+  sitename          => $config[website][name],
 
 	extensions        => $extensions,
 	global_extensions => $global_extensions,


### PR DESCRIPTION
Fixes #904.

At some point during a Puppet upgrade `site` became a [reserved word](https://puppet.com/docs/puppet/7/lang_reserved.html). We need to fix this by changing the name.