### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ synced_folders:
 #  - git@github.com:Chassis/memcache.git
 
 # PHP version
-# Values: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0 (or 5.6.30)
+# Values: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 (or 5.6.30)
 php: 7.4
 
 # Maximum file upload size. This will set post_max_size and upload_max_filesize in PHP and client_max_body_size in Nginx.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -91,7 +91,7 @@ To switch to 5.6 for example:
 
 You can use either a two-part version (``5.6``) or a three-part version
 (``5.6.1``) if you want to pick specifc versions. We support any version between
-5.6.0 and 8.0.x.
+5.6.0 and 8.1.x.
 
 --------------------
 PHP File Upload Size

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -2,7 +2,7 @@
 class chassis::php (
 	$upload_size,
 	$extensions = [],
-	$version = '7.0',
+	$version = '7.4',
 ) {
 	# Ensure add-apt-repository is actually available.
 	if !defined(Package[$::apt::ppa_package]) {
@@ -15,6 +15,13 @@ class chassis::php (
 		require => [
 			Package[ $::apt::ppa_package ],
 			Class['apt'],
+		],
+	}
+
+	apt::ppa { 'ppa:ondrej/php-qa':
+		require => [
+				Package[ $::apt::ppa_package ],
+				Class['apt'],
 		],
 	}
 
@@ -49,7 +56,7 @@ class chassis::php (
 	$prefixed_extensions = prefix( $extensions, "${php_package}-" )
 
 	# Any array of all the versions of php that we support.
-	$php_versions = [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
+	$php_versions = [ '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
 
 	# Work out which version of php we should remove if we've swapped versions.
 	$php_versions_to_remove = delete( $php_versions, $short_ver )
@@ -75,6 +82,7 @@ class chassis::php (
 		require         => [
 			Apt::Pin[$packages],
 			Apt::Ppa['ppa:ondrej/php'],
+			Apt::Ppa['ppa:ondrej/php-qa'],
 			Class['apt::update'],
 			Chassis::Remove_php_version[$php_versions_to_remove]
 		],


### PR DESCRIPTION
Fixes #907.

*Note:* Currently WordPress isn't installed with this. I haven't worked out if it's a MySQL issue or a WP-CLI issue but PHP 8.1 is running so that's good enough for now so people get work on compatibility issues.

![PHP_8 1 0beta3_-_phpinfo_2021-08-28_18-45-35](https://user-images.githubusercontent.com/1377956/131212126-793674da-8e9d-4828-bf75-3a6c0fdd0f50.jpg)
