### PR TITLE
Suggest updating Chassis box in case of package issues.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -100,6 +100,8 @@ There are three logs that we synchronise for you:
 2. ``logs/nginx/error.log`` - This shows any errors that have occurred.
 3. ``logs/nginx/access.log`` = This shows details of any requests that Nginx has served.
 
+It is also recommended to update your Chassis box in case of package installation issues, eg: expired certificates.
+
 Character encoding on Windows machines
 --------------------------------------
 


### PR DESCRIPTION
Using old boxes can sometimes cause certificate expired issues while downloading some of the package. Updating to the latest box can solve this issue, so might be worth it to document it in the troubleshooting section.