### PR TITLE
Ensure avahi is restarted so that custom domains always resolve

### DIFF
--- a/puppet/modules/chassis/manifests/hosts.pp
+++ b/puppet/modules/chassis/manifests/hosts.pp
@@ -39,7 +39,9 @@ class chassis::hosts(
 			Package[ 'avahi-daemon' ],
 			Package[ 'python-avahi' ],
 			File[ '/lib/systemd/system/chassis-hosts.service' ],
+			Exec['restart-avahi']
 		],
-		notify  => Exec['systemctl-daemon-reload'],
 	}
+
+
 }

--- a/puppet/modules/chassis/manifests/init.pp
+++ b/puppet/modules/chassis/manifests/init.pp
@@ -16,12 +16,9 @@ class chassis {
 		package {'sendmail':}
 	}
 
-	if ! defined(Exec['systemctl-daemon-reload']) {
-		exec {'systemctl-daemon-reload':
-			refreshonly => true,
-			path        => '/bin',
-			command     => 'systemctl daemon-reload',
-		}
+	exec {'restart-avahi':
+		path        => '/bin',
+		command     => 'systemctl restart avahi-daemon.service',
 	}
 
 	service { 'nginx':


### PR DESCRIPTION
Fixes #206.

It's crazy to think that it took me this long to realise why this wasn't always working. I got close to fixing this a while back but just forgot to make sure the avahi-daemon.service was restarted each time. 🚀 