### PR TITLE
Add additional packages for PHP cli

### DIFF
--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -57,7 +57,7 @@ class chassis::php (
 
 	# Some of the Chassis extensions define php-cli so let's check for that to prevent failures.
 	if ! defined( Package["${php_package}-cli"] ) {
-		$core_packages = concat( $common_packages, [ "${php_package}-cli" ] )
+		$core_packages = concat( $packages, [ "${php_package}-cli" ] )
 	} else {
 		$core_packages = $packages
 	}

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -44,7 +44,10 @@ class chassis::php (
 		"${php_package}-common",
 		"${php_package}-xml",
 		"${php_package}-mbstring",
-		"${php_package}-zip"
+		"${php_package}-zip",
+		"${php_package}-json",
+		"${php_package}-opcache",
+		"${php_package}-readline"
 	]
 
 	if ! defined( Package["${php_package}-cli"] ) {

--- a/puppet/modules/chassis/manifests/php.pp
+++ b/puppet/modules/chassis/manifests/php.pp
@@ -57,7 +57,12 @@ class chassis::php (
 
 	# Some of the Chassis extensions define php-cli so let's check for that to prevent failures.
 	if ! defined( Package["${php_package}-cli"] ) {
-		$core_packages = concat( $packages, [ "${php_package}-cli" ] )
+		# Because we can't reassign variables in Puppet we have to do some more logic to come up with the core php packages.
+		if defined('$packages') {
+			$core_packages = concat($packages, [ "${php_package}-cli" ])
+		} else {
+			$core_packages = concat($common_packages, [ "${php_package}-cli" ])
+		}
 	} else {
 		$core_packages = $packages
 	}


### PR DESCRIPTION
Fixes #973

Tested with the following PHP versions:
- [x] 5.6 - `_mode: base`
- [x] 7.0 - `_mode: base`
- [x] 7.1 - `_mode: base`
- [x] 7.2 - `_mode: base`
- [x] 7.3 - `_mode: base`
- [x] 7.4 - `_mode: base`
- [x] 8.0 - `_mode: base`
- [x] 8.1 - `_mode: base`
- [x] 5.6 - `_mode: normal`
- [x] 7.0 - `_mode: normal`
- [x] 7.1 - `_mode: normal`
- [x] 7.2 - `_mode: normal`
- [x] 7.3 - `_mode: normal`
- [x] 7.4 - `_mode: normal`
- [x] 8.0 - `_mode: normal`
- [x] 8.1 - `_mode: normal`