### PR TITLE
Use PHP 8 by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ synced_folders:
 
 # PHP version
 # Values: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 (or 5.6.30)
-php: 7.4
+php: 8.0
 
 # Maximum file upload size. This will set post_max_size and upload_max_filesize in PHP and client_max_body_size in Nginx.
 upload_size: 1024M


### PR DESCRIPTION
PHP 8 should be the default going forward.

Example rationale, WordPress VIP is forcing all remaining PHP 7.4 projects to upgrade within the next week.