### PR TITLE
Support MariaDB

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -265,6 +265,31 @@ options::
 
 (Again, don't forget to include all lines, and use spaces for indentation.)
 
+---------------------
+MariaDB Configuration
+---------------------
+
+.. py:data:: mysql
+
+You can change the default database flavour to be MariaDB by overridding the default
+MySQL settings::
+
+   mysql:
+       package_name:
+           mariadb-server
+       mysqld:
+           log-error:
+               /var/log/mysql/mariadb.log
+           pid-file:
+               /var/run/mysqld/mysqld.pid
+           ssl-disable:
+               true
+       mysqld_safe:
+           log-error:
+               /var/log/mysql/mariadb.log
+
+(Again, don't forget to include all lines, and use spaces for indentation.)
+
 -----------------
 Custom Host Names
 -----------------

--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -41,16 +41,24 @@ $mysql_defaults = {
 		'collation-server'              => $config[database][collation],
 		'character-set-server'          => $config[database][charset],
 		'default_authentication_plugin' => 'mysql_native_password'
-	}
+	},
 }
 
-# Allow MySql options to be added or overridden.
+# Allow MySQL options to be added or overridden.
 $mysql_overrides = merge( $mysql_defaults, $config['mysql'] )
+
+# Allow MySQL package name to be overridden so we can easily support MariaDB.
+if $config['mysql'] and $config['mysql']['package_name'] != undef {
+	$mysql_package_name_overrides = $config['mysql']['package_name']
+} else {
+	$mysql_package_name_overrides = 'mysql-server'
+}
 
 class { 'mysql::server':
 	root_password    => 'password',
 	restart          => true,
-	override_options => $mysql_overrides
+	override_options => $mysql_overrides,
+	package_name     => $mysql_package_name_overrides
 }
 
 class { 'chassis':


### PR DESCRIPTION
Fixes #994.

We need to test this with no `mysql` options and also with something like the following config in one of the YAML files:
```
mysql:
  mysqld:
   log-error:
     /var/log/mysql/mariadb.log
   pid-file:
     /var/run/mysqld/mysqld.pid
   ssl-disable:
     true
  mysqld_safe:
    log-error:
      /var/log/mysql/mariadb.log
  package_name:
    mariadb-server
```