### PR TITLE
Forward SSH port via forwarded_port.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -125,8 +125,14 @@ Vagrant.configure("2") do |config|
 		config.vm.box = "bento/ubuntu-22.04"
 	end
 
-	# The Parallels Provider uses a different naming scheme.
+	# The Parallels Provider overrides.
 	config.vm.provider :parallels do |_v, override|
+		# Add port forwarding for ssh.
+		# This method is used rather than config.ssh.forward_agent to work around
+		# an issue with the Vagrant Parallels provider.
+		override.ssh.forward_agent = false
+		override.vm.network "forwarded_port", guest: 22, host: 2222, auto_correct: true
+
 		# Vagrant currently runs under Rosetta on Apple Silicon devices. As a result,
 		# this seems to be the most reliable way to detect whether or not we're
 		# running under ARM64.


### PR DESCRIPTION
Modifies how the SSH port forwarding is configured to account for the Parallels Vagrant provider failing to respect `	config.ssh.forward_agent = true`.

~I've tested it with VirtualBox and it appears to work but it seems a little dodgy so I have left this in draft to consider further.~

I think this is in a suitable state, since the original draft push I have limited the changes so they are only applied if the parallels provider is in use. Otherwise the configuration is unchanged.

@BronsonQuick Are you able to test this on both your Silicon and Intel machines and see if it works for you? 

On parallels the SSH address will still use the 10... IP address, so you'll need to use another method to connect via `127.0.0.1:2222` -- I used Sequel Ace. 