### PR TITLE
Apply VM customisations to Parallels provider.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,6 +54,11 @@ Vagrant.configure("2") do |config|
 		config.vm.define CONF['machine_name']
 	end
 
+	# Convert old VM customisations to new format for backwards compatibility.
+	if CONF["virtualbox"]
+		CONF["virtualmachine"] = CONF["virtualbox"]
+	end
+
 	config.trigger.before [ :provision, :up, :halt ] do |trigger|
 		deprecated_extensions = ''
 		if CONF["version"] >= 3 && ! CONF["extensions"].nil?
@@ -65,6 +70,10 @@ Vagrant.configure("2") do |config|
 				end
 			end
 			trigger.warn = "#{deprecated_extensions}"
+		end
+		# Warn about deprecated 'virtualbox' setting.
+		if CONF["virtualbox"]
+			trigger.warn = "The 'virtualbox' settings in your yaml configuration file has been deprecated. Please change it to 'virtualmachine' instead.\n"
 		end
 	end
 
@@ -90,9 +99,9 @@ Vagrant.configure("2") do |config|
 		vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
 
 		# Customisations from config.local.yaml
-		if CONF['virtualbox']
-			vb.memory = CONF['virtualbox']['memory'] if CONF['virtualbox']['memory']
-			vb.cpus = CONF['virtualbox']['cpus'] if CONF['virtualbox']['cpus']
+		if CONF['virtualmachine']
+			vb.memory = CONF['virtualmachine']['memory'] if CONF['virtualmachine']['memory']
+			vb.cpus = CONF['virtualmachine']['cpus'] if CONF['virtualmachine']['cpus']
 		end
 
 		# Set the machine name for the VirtualBox GUI.
@@ -150,9 +159,9 @@ Vagrant.configure("2") do |config|
 		# The Virtual Machine customizations use `virtualbox` as
 		# the key for backward compatibility but apply to the
 		# Parallels provider too.
-		if CONF['virtualbox']
-			prl.memory = CONF['virtualbox']['memory'] if CONF['virtualbox']['memory']
-			prl.cpus = CONF['virtualbox']['cpus'] if CONF['virtualbox']['cpus']
+		if CONF['virtualmachine']
+			prl.memory = CONF['virtualmachine']['memory'] if CONF['virtualmachine']['memory']
+			prl.cpus = CONF['virtualmachine']['cpus'] if CONF['virtualmachine']['cpus']
 		end
 	end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,6 +99,7 @@ Vagrant.configure("2") do |config|
 		vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
 
 		# Customisations from config.local.yaml
+		# The `virtualbox` value has been deprecated to use `virtualmachine`.
 		if CONF['virtualmachine']
 			vb.memory = CONF['virtualmachine']['memory'] if CONF['virtualmachine']['memory']
 			vb.cpus = CONF['virtualmachine']['cpus'] if CONF['virtualmachine']['cpus']
@@ -156,6 +157,7 @@ Vagrant.configure("2") do |config|
 
 	config.vm.provider "parallels" do |prl|
 		# Use memory and CPU settings from yaml config file.
+		# The `virtualbox` value has been deprecated to use `virtualmachine`.
 		if CONF['virtualmachine']
 			prl.memory = CONF['virtualmachine']['memory'] if CONF['virtualmachine']['memory']
 			prl.cpus = CONF['virtualmachine']['cpus'] if CONF['virtualmachine']['cpus']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
 		config.vm.define CONF['machine_name']
 	end
 
-	# Convert old VM customisations to new format for backwards compatibility.
+	# Convert old VM customisations for backwards compatibility.
 	if CONF["virtualbox"]
 		CONF["virtualmachine"] = CONF["virtualbox"]
 	end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -145,6 +145,17 @@ Vagrant.configure("2") do |config|
 		end
 	end
 
+	config.vm.provider "parallels" do |prl|
+		# Use memory and CPU settings from yaml config file.
+		# The Virtual Machine customizations use `virtualbox` as
+		# the key for backward compatibility but apply to the
+		# Parallels provider too.
+		if CONF['virtualbox']
+			prl.memory = CONF['virtualbox']['memory'] if CONF['virtualbox']['memory']
+			prl.cpus = CONF['virtualbox']['cpus'] if CONF['virtualbox']['cpus']
+		end
+	end
+
 	# Enable SSH forwarding
 	config.ssh.forward_agent = true
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -156,9 +156,6 @@ Vagrant.configure("2") do |config|
 
 	config.vm.provider "parallels" do |prl|
 		# Use memory and CPU settings from yaml config file.
-		# The Virtual Machine customizations use `virtualbox` as
-		# the key for backward compatibility but apply to the
-		# Parallels provider too.
 		if CONF['virtualmachine']
 			prl.memory = CONF['virtualmachine']['memory'] if CONF['virtualmachine']['memory']
 			prl.cpus = CONF['virtualmachine']['cpus'] if CONF['virtualmachine']['cpus']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,7 @@ Vagrant.configure("2") do |config|
 			end
 			trigger.warn = "#{deprecated_extensions}"
 		end
-		# Warn about deprecated 'virtualbox' setting.
+		# Warn about deprecated 'virtualbox' setting if it's present.
 		if CONF["virtualbox"]
 			trigger.warn = "The 'virtualbox' settings in your yaml configuration file has been deprecated. Please change it to 'virtualmachine' instead.\n"
 		end

--- a/config.yaml
+++ b/config.yaml
@@ -19,12 +19,12 @@ version: 5.4.2
 #
 # (When overriding, include vagrant.local if you need it)
 hosts:
-    - vagrant.local
+  - vagrant.local
 
 # Site Configuration
 # (When overriding, include all values)
 website:
-    name: Chassis Site
+  name: Chassis Site
 
 # IP address to use on the private network
 #

--- a/config.yaml
+++ b/config.yaml
@@ -122,7 +122,7 @@ upload_size: 1024M
 machine_name: default
 
 # Virtual Machine customisations.
-# Applies to both the virtualbox an parallels providers. The key is
+# Applies to both the virtualbox and parallels providers. The key is
 # `virtualbox` for both to maintain backwards compatibility.
 # (When overriding, include all values)
 virtualmachine:

--- a/config.yaml
+++ b/config.yaml
@@ -125,7 +125,7 @@ machine_name: default
 # Applies to both the virtualbox an parallels providers. The key is
 # `virtualbox` for both to maintain backwards compatibility.
 # (When overriding, include all values)
-virtualbox:
+virtualmachine:
     # Memory, in megabytes.
     #
     # (e.g. 1024)

--- a/config.yaml
+++ b/config.yaml
@@ -19,12 +19,12 @@ version: 5.4.2
 #
 # (When overriding, include vagrant.local if you need it)
 hosts:
-  - vagrant.local
+    - vagrant.local
 
 # Site Configuration
 # (When overriding, include all values)
 website:
-  name: Chassis Site
+    name: Chassis Site
 
 # IP address to use on the private network
 #

--- a/config.yaml
+++ b/config.yaml
@@ -121,7 +121,10 @@ upload_size: 1024M
 # NOTE: If changed the machine will need to be re-created and should ideally be destroyed before any change
 machine_name: default
 
-# VirtualBox-specific customisations.
+# Virtual Machine customisations.
+# Applies to both the virtualbox an parallels providers. The key is
+# `virtualbox` for both to maintain backwards compatibility.
+# (When overriding, include all values)
 virtualbox:
     # Memory, in megabytes.
     #

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -515,17 +515,17 @@ Machine Customisations
 
 The underlying virtual machine managed by Vagrant can be customised, but depends on which provider you are using.
 
-----------
-VirtualBox
-----------
+-------------------------------------------
+Virtual Machines - VirtualBox and Parallels
+-------------------------------------------
 
-.. py:data:: virtualbox
+.. py:data:: virtualmachine
 
-When using VirtualBox, you can customise how much memory (in megabytes) and how many virtual CPUs will be assigned to the machine. The default values for both (``null``) are to use the VirtualBox defaults (1024 MB of RAM, and 2 vCPUs).
+When using VirtualBox or Parallels, you can customise how much memory (in megabytes) and how many virtual CPUs will be assigned to the machine. The default values for both (``null``) are to use the defaults are (1024 MB of RAM, and 2 vCPUs).
 
 .. code-block:: yaml
 
-   virtualbox:
+   virtualmachine:
       memory: null
       cpus: null
 

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -9,7 +9,7 @@ Networking
 ----------
 
 Chassis VMs use the networking features provided by Vagrant and the underlying
-VM management (VirtualBox, VMWare Fusion, etc). The VM is connected to the host
+VM management (VirtualBox, Parallels, VMWare Fusion, etc). The VM is connected to the host
 using a `private network`_, with a dynamically assigned IP address (unless a
 static IP is :ref:`specified in your config <config-ip>`).
 


### PR DESCRIPTION
Applies the `virtualbox` customisations to the Parallels provider.

I've kept the name as `virtualbox` rather than changing it to `virtualmachine` or similar in order to maintain backward compatibility.

Docs reference: https://parallels.github.io/vagrant-parallels/docs/configuration.html