### PR TITLE
Always set the site URL for single site installs, never for MS.

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -87,7 +87,7 @@ if ( file_exists( WP_CONTENT_DIR . '/config.php' ) ) {
 // =====================
 // URL hacks for Vagrant
 // =====================
-if ( WP_LOCAL_DEV && ! defined('WP_SITEURL') && ! defined( 'WP_INSTALLING' ) ) {
+if ( WP_LOCAL_DEV && ! defined('WP_SITEURL') && ! defined( 'MULTISITE' ) ) {
 	define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/wp');
 
 	if ( ! defined( 'WP_HOME' ) ) {


### PR DESCRIPTION
Replaces the check for whether `WP_SITEURL` should be set from checking the `WP_INSTALLING` constant to the `MULTISITE` constant.

This ensures that default pretty permalinks are set up for single site installs in `wp_install_maybe_enable_pretty_permalinks()`. Without the constant, the expected pingback header is incorrect.

Multisite doesn’t use the `WP_SITEURL` or `WP_HOMEURL` constants so therre should be no effect for sites running on multisite.

This modifies the approach introduced in #351 for #336 in which Chassis was setting up permalinks incorrectly (using a `/wp` home page). In the issue it was mentioned there was a potential bug in WP Core, so this may effect people replacing WP with very old versions.

**Testing**

Single Site:

1. Run `vagrant destroy; vagrant up` -- remember to answer the prompt to destroy the box before getting a coffee
2. Ensure that the Hello World post uses the default pretty permalink `http://vagrant.local/2025/05/15/hello-world/`
3. Ensure that links to the front end of the site use `vagrant.local`
4. Ensure that links to the admin of the site use `vagrant.local/wp/wp-admin`

Multisite (sub-directory)

1. Run `vagrant destroy; vagrant up` -- remember to answer the prompt to destroy the box before getting a coffee
2. Ensure the main site uses the correct URL for the Hello World Post ``http://vagrant.local/blog/2025/05/15/hello-world/`
3. Ensure that links to the front end of the site use `vagrant.local`
4. Ensure that links to the admin of the site use `vagrant.local/wp-admin`
5. Create a subsite, `two`
6. Ensure that links to the front end of the subsite use `vagrant.local/two/`
7. Ensure that links to the admin of the subsite use `vagrant.local/two/wp-admin`

Multisite (sub-domain)

1. Run `vagrant destroy; vagrant up` -- remember to answer the prompt to destroy the box before getting a coffee
2. Ensure the main site uses the correct URL for the Hello World Post ``http://vagrant.local/blog/2025/05/15/hello-world/`
3. Ensure that links to the front end of the site use `vagrant.local`
4. Ensure that links to the admin of the site use `vagrant.local/wp-admin`
5. Create a subsite, `two`
6. Ensure that links to the front end of the subsite use `two.vagrant.local`
7. Ensure that links to the admin of the subsite use `two.vagrant.local/wp-admin`


